### PR TITLE
Adding primer-marketing to the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # HEAD
 
+# 4.4.0
+
+- Adding primer-marketing module to primer
+
+# 4.3.0
+
+- Using primer-core and primer-product modules
+
 # 4.1.0
 
 - Added: [primer-markdown](https://github.com/primer/markdown) to the build

--- a/index.scss
+++ b/index.scss
@@ -13,3 +13,4 @@
 // Global requirements
 @import "primer-core/index.scss";
 @import "primer-product/index.scss";
+@import "primer-marketing/index.scss";

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "primer-core": "^1.0.0",
+    "primer-marketing": "^1.0.0",
     "primer-product": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds the [primer-marketing](https://github.com/primer/primer-marketing) module to the build. Which groups together these primer marketing bundles

```
"primer-breadcrumb": "^0.1.0",
"primer-cards": "^0.1.0",
"primer-marketing-support": "^0.1.1",
"primer-marketing-type": "^0.1.1",
"primer-page-headers": "^0.1.0",
"primer-page-sections": "^0.1.0",
"primer-tables": "^0.1.0"
```

cc @pmarsceill @sophshep 