### PR TITLE
Make lerna a dev dependency

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-rc.2",
+  "lerna": "2.0.0-rc.5",
   "packages": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -2,8 +2,13 @@
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap",
+    "clean": "lerna clean",
+    "updated": "lerna updated",
+    "diff": "lerna diff",
     "publish": "lerna publish",
-    "updated": "lerna updated"
+    "skipgit": "lerna publish --skip-git",
+    "dev": "lerna publish --npm-tag=dev",
+    "rc": "lerna publish --npm-tag=rc"
   },
   "devDependencies": {
     "lerna": "^2.0.0-rc.5"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "publish": "lerna publish",
     "updated": "lerna updated"
   },
-  "dependencies": {
+  "devDependencies": {
     "lerna": "^2.0.0-rc.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "updated": "lerna updated"
   },
   "devDependencies": {
-    "lerna": "^2.0.0-rc.2"
+    "lerna": "^2.0.0-rc.5"
   }
 }


### PR DESCRIPTION
**This pr moves Lerna back to a dev dependency and adds some useful run scripts.**

I don't think we want this as a dependency since it's not required in production and means contributors don't need to install it globally. I added some scripts that I thought would be the most useful common scripts for contributors:

```
"scripts": {
    "bootstrap": "lerna bootstrap",
    "clean": "lerna clean",
    "updated": "lerna updated",
    "diff": "lerna diff",
    "publish": "lerna publish",
    "skipgit": "lerna publish --skip-git",
    "dev": "lerna publish --npm-tag=dev",
    "rc": "lerna publish --npm-tag=rc"
  },
```

Let me know if you think there are other essential scripts. I think we can refine this once we're more familiar with Lerna, and there are some additional steps we'll need to document particularly for versioning the `primer-css` package. For us maintainers I think we'll want to have Lerna installed globally so that we can use the full sweet of scripts to debug issues.

I've tested the scripts and they work. Only thing is that some of them trigger an error message if they can't run, i.e. if there are no updated files it will throw and error rather than saying "no packages need updating", but if there are packages that need updating then it shows you them. 

Output with no updates after running `lerna updated` vs `npm run updated`:
<img width="990" alt="screenshot 2017-06-25 12 52 52" src="https://user-images.githubusercontent.com/334891/27518082-6efe0744-59a5-11e7-8e00-d651aefee16f.png">

Output when there are updates after running `npm run updated`:
<img width="584" alt="screenshot 2017-06-25 12 31 43" src="https://user-images.githubusercontent.com/334891/27518087-8a169ac8-59a5-11e7-98eb-7c6b1a5ed60f.png">

I'll include this in the contributing docs so that people don't freak out. I figure this is something the Lerna folks will fix at some point.

cc @primer/ds-core 