### PR TITLE
Add max-width and max-height on img

### DIFF
--- a/modules/primer-base/lib/base.scss
+++ b/modules/primer-base/lib/base.scss
@@ -34,6 +34,11 @@ strong {
   font-weight: $font-weight-bold;
 }
 
+img {
+  max-width: 100%;
+  max-height: 100%;
+}
+
 // Horizontal lines
 //
 // TODO-MDO: Remove `.rule` from everywhere and replace with `<hr>`s


### PR DESCRIPTION
I often find myself adding inline styles or defining custom classes just to set max-width on an image. What do you think about setting `max-width` and `max-height` on `img`? Is ther a situation where this wouldn't be the expected behavior?

I'm not sure the best place for this rule. I mostly have to do this on marketing websites, but there have been a few occasions in apps as well.