### PR TITLE
CI build/release fixes

### DIFF
--- a/script/release-candidate
+++ b/script/release-candidate
@@ -8,10 +8,6 @@ package=primer-css
 npm_tag=rc
 log=/tmp/rc.log
 
-function bump() {
-  npm version --no-git $@
-}
-
 # get the version we're publishing as a release candidate
 local_version=$(jq -r .version modules/$package/package.json)
 if [[ $local_version =~ "-" ]]; then
@@ -25,6 +21,9 @@ fi
 rc_version=$(npm info $package@$npm_tag version)
 echo "📦  Published version for $package@$npm_tag: $rc_version"
 rc_release=${rc_version%-*}
+if [[ $local_version != $rc_release ]]; then
+  rc_version=$local_version
+fi
 
 # determine the 
 next_version=$(
@@ -47,12 +46,14 @@ for module_dir in $module_dirs; do
 
   # determine the local version (in git)
   module_version=$(jq -r .version package.json)
+  # strip the rc version, just in case
+  module_version=${module_version%-*}
   module_next_version="$module_version$pre_version"
 
   echo "$module@$module_version => $module_next_version"
   # "upgrade" to the most recent RC version so that
   # `npm version prerelease` can increment automatically
-  bump --quiet "$module_next_version" >> $log
+  npm version --no-git --quiet "$module_next_version" >> $log
 
   popd > /dev/null
 done

--- a/script/release-candidate
+++ b/script/release-candidate
@@ -59,4 +59,4 @@ for module_dir in $module_dirs; do
 done
 
 # publish all the things!
-lerna exec --bail -- npm publish --tag=$npm_tag
+lerna exec --bail=false -- npm publish --tag=$npm_tag


### PR DESCRIPTION
This PR contains potential fixes for #263 and #268. We'll need to run these through the release process to test both the RC and "final" release phases.

**The only catch is that we should not `npm run bump` when we do the release branch to test the fix for v9.1.1 being published.**