### PR TITLE
Hotfix for release publishing

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -8,14 +8,6 @@ args=$@
 event=$TRAVIS_EVENT_TYPE
 branch=$TRAVIS_BRANCH
 
-echo "🐛  script/cibuild"
-(
-  echo "TRAVIS_EVENT_TYPE,$TRAVIS_EVENT_TYPE"
-  echo "TRAVIS_BRANCH,$TRAVIS_BRANCH"
-  echo "TRAVIS_PULL_REQUEST,$TRAVIS_PULL_REQUEST"
-  echo "TRAVIS_PULL_REQUEST_BRANCH,$TRAVIS_PULL_REQUEST_BRANCH"
-) | column -t -s=,
-
 # the presence of $TRAVIS_PULL_REQUEST_BRANCH tells us
 # whether this is a pull request
 if [[ "$event" = "pull_request" ]]; then

--- a/script/try-publish
+++ b/script/try-publish
@@ -3,7 +3,7 @@ set -e
 # pwd
 package=$(jq .name package.json)
 version=$(jq .version package.json)
-published=$(npm info "$package@$version")
+published=$(npm info "$package@$version version")
 if [[ "$version" = "$published" ]]; then
   echo "⚠️   $package@$version is already published!"
 else


### PR DESCRIPTION
Okay, I'm tired of going through the whole release process for CI fixes, so this is a hotfix straight to master. I also removed some of the debugging output from `script/cibuild` that isn't necessary anymore.

For the record, the issue was that in `script/try-publish` I was calling `npm version $package@$version` to determine if the version had already been published then comparing the returned value with the local version, but the entire JSON blob is returned without the additional `version` argument. I really hope this solves it so we can move on!