### PR TITLE
Another hotfix for releasing

### DIFF
--- a/script/try-publish
+++ b/script/try-publish
@@ -3,10 +3,10 @@ set -e
 # pwd
 package=$(jq .name package.json)
 version=$(jq .version package.json)
-published=$(npm info "$package@$version version")
+published=$(npm info $package@$version version)
 if [[ "$version" = "$published" ]]; then
   echo "⚠️   $package@$version is already published!"
 else
-  echo "📦  npm publish: $package@$version"
+  echo "📦  Publishing: $package@$version (published: $published)"
   npm publish $@
 fi


### PR DESCRIPTION
Pop quiz! What's wrong with this line from `script/try-publish`?

```sh
published=$(npm info "$package@$version version")
```

1. There's no need to quote `"$package@$version"` here.
1. The quotes produce calls like ` npm info "primer-css@9.1.1 version"`, which will always return nothing because the `version` bit is included in the positional argument.
1. All of the above.