### PR TITLE
Update contributor guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Example:
 
 ## Feature requests
 
-Feature requests are welcome but take a moment to find out whether your idea fits with the scope and aims of the project. It's up to *you* to make a strong case to convince the project's developers of the merits of this feature. Please provide as much detail and context as possible.
+Feature requests are welcome, but take a moment to find out whether your idea fits with the scope and aims of the project. It's up to *you* to make a strong case to convince the project's developers of the merits of this feature. Please provide as much detail and context as possible.
 
 ## Pull requests
 
@@ -61,13 +61,16 @@ Good pull requests—patches, improvements, new features—are a fantastic help.
 
 Anyone can open a pull request on Primer CSS. You do not need to work at GitHub or be a member of the org to open a pull request. 
 
-1. Fork and clone the primer/primer-css repository.
+1. Fork and clone [this repository](https://github.com/primer/primer-css).
 2. Configure and install the dependencies: `npm install`
 3. Check out the dev branch `git checkout dev`
 3. Create a new branch from dev `git checkout -b my-branch-name`
-4. Make your changes, add and commit them.
-5. Push your branch and open a pull request. Add a comment describing your proposed changes and request a review from `@primer/ds-core`.
-6. Wait for CI tests to pass, if they do not, fix the errors or ask for help from `@primer/ds-core`.
+4. Make your changes and commit them.
+5. Push your branch and open a pull request against `dev`. Add a comment describing your proposed changes and request a review from `@primer/ds-core`.
+6. Wait for CI tests to finish.
+  - If the tests pass, you should see a status check telling you which alpha version of primer-css you can install with npm to test your work in other projects.
+  - If the tests fail, review the logs and address any issues.
+  - If the builds fail for any other reason (as they occasionally do), they may need to be manually restarted.
 7. When CI tests pass, a new npm alpha release will be posted under the CI checks, you can use this npm version for testing in your project or with a GitHub site if you are staff.
 8. Pat yourself on the back and wait for your pull request to be reviewed.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Good pull requests—patches, improvements, new features—are a fantastic help.
 
 **Please ask first** before embarking on any significant pull request (e.g. implementing features, refactoring code, porting to a different language), otherwise you risk spending a lot of time working on something that the project's developers might not want to merge into the project.
 
-## Updating Primer modules
+### Updating Primer modules
 
 Anyone can open a pull request on Primer CSS. You do not need to work at GitHub or be a member of the org to open a pull request. 
 
@@ -66,8 +66,8 @@ Anyone can open a pull request on Primer CSS. You do not need to work at GitHub 
 3. Check out the dev branch `git checkout dev`
 3. Create a new branch from dev `git checkout -b my-branch-name`
 4. Make your changes, add and commit them.
-5. Push your branch and open a pull request, request a review from @primer/ds-core
-6. Wait for CI tests to pass, if they do not, fix the errors or ask for help from @primer/ds-core.
+5. Push your branch and open a pull request. Add a comment describing your proposed changes and request a review from `@primer/ds-core`.
+6. Wait for CI tests to pass, if they do not, fix the errors or ask for help from `@primer/ds-core`.
 7. When CI tests pass, a new npm alpha release will be posted under the CI checks, you can use this npm version for testing in your project or with a GitHub site if you are staff.
 8. Pat yourself on the back and wait for your pull request to be reviewed.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -57,18 +57,22 @@ Good pull requests—patches, improvements, new features—are a fantastic help.
 
 **Please ask first** before embarking on any significant pull request (e.g. implementing features, refactoring code, porting to a different language), otherwise you risk spending a lot of time working on something that the project's developers might not want to merge into the project.
 
-Adhering to the following process is the best way to get your work included in the project:
+## Updating Primer modules
 
-1. Fork and clone the repository
+Anyone can open a pull request on Primer CSS. You do not need to work at GitHub or be a member of the org to open a pull request. 
+
+1. Fork and clone the primer/primer-css repository.
 2. Configure and install the dependencies: `npm install`
-3. Create a new branch: `git checkout -b my-branch-name`
-4. Make your change, add tests, and make sure the tests still pass
-5. Push to your fork and [submit a pull request][pr]
-6. Pat your self on the back and wait for your pull request to be reviewed and merged.
+3. Check out the dev branch `git checkout dev`
+3. Create a new branch from dev `git checkout -b my-branch-name`
+4. Make your changes, add and commit them.
+5. Push your branch and open a pull request, request a review from @primer/ds-core
+6. Wait for CI tests to pass, if they do not, fix the errors or ask for help from @primer/ds-core.
+7. When CI tests pass, a new npm alpha release will be posted under the CI checks, you can use this npm version for testing in your project or with a GitHub site if you are staff.
+8. Pat yourself on the back and wait for your pull request to be reviewed.
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
-- Follow the [style guide][style].
 - Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,9 +68,9 @@ Anyone can open a pull request on Primer CSS. You do not need to work at GitHub 
 4. Make your changes and commit them.
 5. Push your branch and open a pull request against `dev`. Add a comment describing your proposed changes and request a review from `@primer/ds-core`.
 6. Wait for CI tests to finish.
-  - If the tests pass, you should see a status check telling you which alpha version of primer-css you can install with npm to test your work in other projects.
-  - If the tests fail, review the logs and address any issues.
-  - If the builds fail for any other reason (as they occasionally do), they may need to be manually restarted.
+   - If the tests pass, you should see a status check telling you which alpha version of primer-css you can install with npm to test your work in other projects.
+   - If the tests fail, review the logs and address any issues.
+   - If the builds fail for any other reason (as they occasionally do), they may need to be manually restarted.
 7. When CI tests pass, a new npm alpha release will be posted under the CI checks, you can use this npm version for testing in your project or with a GitHub site if you are staff.
 8. Pat yourself on the back and wait for your pull request to be reviewed.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Example:
 
 ## Feature requests
 
-Feature requests are welcome. But take a moment to find out whether your idea fits with the scope and aims of the project. It's up to *you* to make a strong case to convince the project's developers of the merits of this feature. Please provide as much detail and context as possible.
+Feature requests are welcome but take a moment to find out whether your idea fits with the scope and aims of the project. It's up to *you* to make a strong case to convince the project's developers of the merits of this feature. Please provide as much detail and context as possible.
 
 ## Pull requests
 
@@ -60,7 +60,7 @@ Good pull requests—patches, improvements, new features—are a fantastic help.
 Adhering to the following process is the best way to get your work included in the project:
 
 1. Fork and clone the repository
-2. Configure and install the dependencies: `bower install`
+2. Configure and install the dependencies: `npm install`
 3. Create a new branch: `git checkout -b my-branch-name`
 4. Make your change, add tests, and make sure the tests still pass
 5. Push to your fork and [submit a pull request][pr]


### PR DESCRIPTION
I've updated the contribution guidelines for updating existing modules. I think this is enough for the public contribution guidelines for now. After seeing that there's a bunch of other stuff in here such as bug reporting, I think adding all the docs for githubbers will be a bit too much here so I think I'll add the detailed docs back in the style guide. When it's public, we can link to that from here too.

cc @primer/ds-core 