### PR TITLE
Adding the docs test to primer-alerts

### DIFF
--- a/modules/primer-alerts/package.json
+++ b/modules/primer-alerts/package.json
@@ -17,10 +17,11 @@
     "url": "https://github.com/primer/primer-css/issues"
   },
   "scripts": {
+    "test-docs": "ava --verbose ../../tests/modules/test-*.js",
     "build": "primer-module-build index.scss",
     "prepare": "npm run build",
     "lint": "stylelint **/*.scss -c .stylelintrc.json -s scss",
-    "test": "npm-run-all -s build lint"
+    "test": "npm-run-all -s build lint test-docs"
   },
   "dependencies": {
     "primer-support": "^4.1.1"


### PR DESCRIPTION
This pull adds the docs test to the primer-alerts module which ensures that all selectors in the scss are mentioned in the README.md or a docs folder.

⚠️  This test currently fails for the following selectors, docs will need to be written for them

```
1 test failed [21:40:07]
Every selector class is documented
/home/travis/build/primer/primer-css/tests/modules/test-document-styles.js:59
I did not find documentation for the ".warning" selector(s) in the primer-alerts module.
```