### PR TITLE
Move access tokens to .travis.yml; don't fail CI on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 env:
   global:
     # npm
-    - secure: "LM0fPkeaihq3SurKho+0kWoL+ZHvXht9sZ0cnGiWTbQSE/mmQ7ekZ6YoUyITNoSJzjXfZGRMFA65bXlC0PddZ5Egrgj/AkNUs532QpABJltYXgWlIcPXUIXIWrOWWB1DNxvHSatkNYU1oM8/RgDqV8HEBLDaftxfyjJH1gfyX1A="
+    - secure: "EZewKKWQXmtCwPtYrPZq4OQblv2OyXR61qBIl3pOxGNVG2BCjD6VOgSaiYqkA9Qbt+ihfwQkiiLvTB68gbvRSiBFV9i+XLzKzt4S8CDI5RhTLAxZB3eQFVZRYzldchzWI4sdNhTvYS1kYXmsXQZD6vJmPSnFvOI/ddfzqvnNL4M="
     # github
     - secure: "J+1oWjvvXjyrwkY/4IFWKdN/weFmQcPwlRuFG4R0Gb3rYe4nqtC9l68sJvmS8asc8dQMhOhcUZCH6sjvo7l2WD4NuK4umPSbs+rJNUsfbvH4pZjStQIj/3ll1OfQelGDWAYQWhIfciYY4F3Bp0ZWTfKOppLQ2AVIYu1fPVXDdlo="
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: node_js
 node_js:
   - 7
 
+env:
+  global:
+    # npm
+    - secure: "LM0fPkeaihq3SurKho+0kWoL+ZHvXht9sZ0cnGiWTbQSE/mmQ7ekZ6YoUyITNoSJzjXfZGRMFA65bXlC0PddZ5Egrgj/AkNUs532QpABJltYXgWlIcPXUIXIWrOWWB1DNxvHSatkNYU1oM8/RgDqV8HEBLDaftxfyjJH1gfyX1A="
+    # github
+    - secure: "J+1oWjvvXjyrwkY/4IFWKdN/weFmQcPwlRuFG4R0Gb3rYe4nqtC9l68sJvmS8asc8dQMhOhcUZCH6sjvo7l2WD4NuK4umPSbs+rJNUsfbvH4pZjStQIj/3ll1OfQelGDWAYQWhIfciYY4F3Bp0ZWTfKOppLQ2AVIYu1fPVXDdlo="
+
 before_install:
   - npm config set "//registry.npmjs.org/:_authToken=\${NPM_API_KEY}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ env:
     # github
     - secure: "J+1oWjvvXjyrwkY/4IFWKdN/weFmQcPwlRuFG4R0Gb3rYe4nqtC9l68sJvmS8asc8dQMhOhcUZCH6sjvo7l2WD4NuK4umPSbs+rJNUsfbvH4pZjStQIj/3ll1OfQelGDWAYQWhIfciYY4F3Bp0ZWTfKOppLQ2AVIYu1fPVXDdlo="
 
-before_install:
-  - npm config set "//registry.npmjs.org/:_authToken=\${NPM_API_KEY}"
-
 before_script:
   - lerna bootstrap
 
@@ -19,6 +16,8 @@ script:
   - npm test
 
 after_success:
+  # this will short-circuit the publish step if it fails to interpolate $NPM_API_KEY
+  - npm config set "//registry.npmjs.org/:_authToken=\${NPM_API_KEY}"
   - script/after_success
 
 deploy:


### PR DESCRIPTION
This encrypts our `NPM_API_KEY` and `GH_STATUS_TOKEN` environment variables into the config so that we can track when they get changed. The npm status token is the same as what's in our Travis repo settings right now, but the GitHub status token is from [primer-css](/primer-css).

While I was in there, I moved the `npm config` call down into the `after_success` section so that the absence of the `NPM_API_KEY` env var (which is encrypted, and isn't set when building forks) doesn't short-circuit the entire build.

Fixes #262, #301.