### PR TITLE
Do not suppress opacity transition for tooltipped-no-delay

### DIFF
--- a/modules/primer-tooltips/lib/tooltips.scss
+++ b/modules/primer-tooltips/lib/tooltips.scss
@@ -71,8 +71,7 @@
 .tooltipped-no-delay:focus {
   &::before,
   &::after {
-    opacity: 1;
-    animation: none;
+    animation-delay: 0s;
   }
 }
 


### PR DESCRIPTION
As far as I understand (the git history is not too easy to follow on this repo :/), when `tooltipped-no-delay` was added [here](https://github.com/primer/primer-css/pull/181), there were no animations/transitions on the tooltip.

This commit removes the delay, so that the transition starts immediately, instead of suppressing the transition entirely. It effectively makes the 2 variants differ by only the initial delay (like the name suggests).

I noticed that on a project where both variants are used at the same time: there are tooltips on buttons (which warrant the delay), and tooltips on help icons, which have no delay. The difference in delay did not shock the eye, but the lack of transition felt off :)