### PR TITLE
Fix .form-select appearance.

### DIFF
--- a/modules/primer-forms/lib/form-select.scss
+++ b/modules/primer-forms/lib/form-select.scss
@@ -12,7 +12,8 @@
   // IE9 hacks to hide the background-image
   background-image: none \9;
   background-size: 8px 10px;
-  appearance: none;
+  -webkit-appearance: none;
+          appearance: none;
 
   // Hides the default caret in IE11
   &::-ms-expand {


### PR DESCRIPTION
appearance: none; did not work on Safari 10.1.1 and Chrome 60. It works with -webkit-appearance: none;