### PR TITLE
Moar docs

### DIFF
--- a/modules/primer-layout/docs/grid.md
+++ b/modules/primer-layout/docs/grid.md
@@ -1,0 +1,390 @@
+---
+title: Grid
+status: New release
+status_issue: https://github.com/github/design-systems/issues/88
+source: https://github.com/primer/primer-css/blob/master/modules/primer-layout/lib/grid.scss
+---
+
+The grid is 12 columns and percentage-based. The number of columns a container spans can be adjusted across breakpoints for responsive layouts. The grid system works with a variety of layout utilities to achieve different results.
+
+{:toc}
+
+## Float based grid
+
+Use `.clearfix` on the container and float utilities with columns for a floated grid layout.
+
+```html
+<div class="container-lg clearfix">
+  <div class="col-4 float-left border p-4">
+    My column
+  </div>
+  <div class="col-4 float-left border p-4">
+    Looks better
+  </div>
+  <div class="col-4 float-left border p-4">
+    Than your column
+  </div>
+</div>
+```
+
+### Reversed grid
+
+To reverse the order of columns, use `float-right` to float columns to the right.
+
+```html
+<div class="container-lg clearfix">
+  <div class="col-4 float-right border p-4">
+    One
+  </div>
+  <div class="col-4 float-right border p-4">
+    Two
+  </div>
+  <div class="col-4 float-right border p-4">
+    Three
+  </div>
+</div>
+```
+
+## Nesting
+You can infinitely nest grid layouts within other columns since the column widths are percentage based. With great flexibility comes great responsibility - be sensible with how far you nest!
+
+```html
+<div class="clearfix">
+  <div class="col-6 float-left px-1">
+    <div class="border p-1">Unnested</div>
+  </div>
+  <div class="col-6 float-left">
+    <div class="clearfix">
+      <div class="col-6 float-left px-1">
+        <div class="border p-1">1 x Nested</div>
+      </div>
+      <div class="col-6 float-left">
+        <div class="col-6 float-left px-1">
+          <div class="border p-1">2 x Nested</div>
+        </div>
+        <div class="col-6 float-left px-1">
+          <div class="border p-1">2 x Nested</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+## Centering a column
+
+Use `.mx-auto` to center columns within a container.
+```html
+<div class="border">
+  <div class="col-6 p-2 mx-auto border">
+    This column is the center of my world.
+  </div>
+</div>
+```
+
+
+## Column widths
+Column widths can be used with any other block or inline-block elements to add percentage-based widths.
+```html
+<div>
+  <div class="col-4 float-right p-2 border text-red">
+    <%= octicon "heart" %> Don't go bacon my heart.
+  </div>
+  <p>T-bone drumstick alcatra ribeye. Strip steak chuck andouille tenderloin bacon tri-tip ball tip beef capicola rump. Meatloaf bresaola drumstick ball tip salami. Drumstick ham bacon alcatra pig porchetta, spare ribs leberkas pork belly.</p>
+</div>
+```
+
+## Offset columns
+
+Using column offset classes can push a div over X number of columns. They work responsively using the [breakpoints outlined below](/styleguide/css/modules/grid#responsive-grids).
+
+```html
+<div class="clearfix">
+  <div class="offset-1 col-3 border p-3">.offset-1</div>
+  <div class="offset-2 col-3 border p-3">.offset-2</div>
+</div>
+```
+
+## Gutters
+Use gutter styles or padding utilities to create gutters. You can use the default gutter style, `gutter`, or either of its modifiers, `gutter-condensed` or `gutter-spacious`. Gutter styles also support responsive breakpoint modifiers. Gutter styles add padding to the left and right side of each column and apply a negative margin to the container to ensure content inside each column lines up with content outside of the grid.
+
+```html
+<div class="clearfix gutter-md-spacious border">
+  <div class="col-3 float-left">
+    <div class="border p-3">.col-md-3</div>
+  </div>
+  <div class="col-3 float-left">
+    <div class="border p-3">.col-md-3</div>
+  </div>
+  <div class="col-3 float-left">
+    <div class="border p-3">.col-md-3</div>
+  </div>
+  <div class="col-3 float-left">
+    <div class="border p-3">.col-md-3</div>
+  </div>
+</div>
+```
+
+Use padding utilities to create gutters for more customized layouts.
+
+```html
+<div class="container-lg clearfix">
+  <div class="col-3 float-left pr-2 mb-3">
+    <div class="border bg-gray-light">.pr-2</div>
+  </div>
+  <div class="col-3 float-left px-2 mb-3">
+    <div class="border bg-gray-light">.px-2</div>
+  </div>
+  <div class="col-3 float-left px-2 mb-3">
+    <div class="border bg-gray-light">.px-2</div>
+  </div>
+  <div class="col-3 float-left pl-2 mb-3">
+    <div class="border bg-gray-light">.pl-2</div>
+  </div>
+</div>
+<div class="container-lg clearfix">
+  <div class="col-3 float-left pr-2">
+    <div class="border bg-gray-light">.pr-2</div>
+  </div>
+  <div class="col-9 float-left pl-2">
+    <div class="border bg-gray-light">.pl-2</div>
+  </div>
+</div>
+```
+
+
+## Inline-block grids
+Use column widths with `d-inline-block` as an alternative to floated grids.
+
+```html
+<div>
+  <div class="col-4 d-inline-block border">
+    .col-4 .d-inline-block
+  </div><!--
+  --><div class="col-4 d-inline-block border">
+    .col-4 .d-inline-block
+  </div><!--
+  --><div class="col-4 d-inline-block border">
+    .col-4 .d-inline-block
+  </div>
+</div>
+```
+
+You can use column widths and other utilities on elements such as lists to create the layout you need while keeping the markup semantically correct.
+```html
+<ul class="list-style-none">
+  <li class="d-inline-block col-2 p-2"><img class="width-full avatar" src="/broccolini.png" alt="broccolini" /></li><!--
+  --><li class="d-inline-block col-2 p-2"><img class="width-full avatar" src="/jonrohan.png" alt="jonrohan" /></li><!--
+  --><li class="d-inline-block col-2 p-2"><img class="width-full avatar" src="/muan.png" alt="muan" /></li><!--
+  --><li class="d-inline-block col-2 p-2"><img class="width-full avatar" src="/pmarsceill.png" alt="pmarsceill" /></li><!--
+  --><li class="d-inline-block col-2 p-2"><img class="width-full avatar" src="/sophshep.png" alt="sophshep" /></li><!--
+  --><li class="d-inline-block col-2 p-2"><img class="width-full avatar" src="/cmwinters.png" alt="cmwinters" /></li><!--
+  --><li class="d-inline-block col-2 p-2"><img class="width-full avatar" src="/jeejkang.png" alt="jeejkang" /></li><!--
+  --><li class="d-inline-block col-2 p-2"><img class="width-full avatar" src="/mdo.png" alt="mdo" /></li>
+</ul>
+```
+
+
+## Display table grids
+Using [display table utilities](/styleguide/css/utilities/layout#display) with columns gives you some alternative layout options.
+
+A useful example is being able to keep the height of the container equal across a row when the length of content may differ.
+
+```html
+<div class="d-table col-12">
+  <div class="col-4 d-table-cell border p-2">
+    Bacon ipsum dolor amet leberkas pork pig kielbasa shankle ribeye meatball, salami alcatra venison.
+  </div><!--
+  --><div class="col-4 d-table-cell border p-2">
+    Pork chop cupim cow turkey frankfurter, landjaeger fatback hamburger meatball salami spare ribs. Rump tenderloin salami, hamburger frankfurter landjaeger andouille.
+  </div><!--
+  --><div class="col-4 d-table-cell border p-2">
+    Brisket tongue frankfurter cupim strip steak rump picanha pancetta pork pig kevin pastrami biltong. Shankle venison meatball swine sausage ground round. Tail pork loin ribeye kielbasa short ribs pork chop.
+  </div>
+</div>
+```
+You can also create an alternative [media object](/styleguide/css/utilities/layout#the-media-object) layout with `.display-table` and column widths.
+
+```html
+<div class="d-table col-12">
+  <div class="col-2 d-table-cell v-align-middle">
+    <img class="width-full avatar" src="/github.png" alt="github" />
+  </div>
+  <div class="col-10 d-table-cell v-align-middle pl-4">
+    <h1 class="text-normal lh-condensed">GitHub</h1>
+    <p class="h4 text-gray text-normal mb-2">How people build software.</p>
+    <a class="text-gray text-small" href="#url">https://github.com/about</a>
+  </div>
+</div>
+```
+
+Note that table cells will fill the width of their container even when the total columns doesn't add up to 12.
+
+```html
+<div class="d-table col-12">
+  <div class="col-4 d-table-cell border">
+    .col-4 .d-table-cell
+  </div><!--
+  --><div class="col-4 d-table-cell border">
+    .col-4 .d-table-cell
+  </div><!--
+  --><div class="col-2 d-table-cell border">
+    .col-2 .d-table-cell
+  </div>
+</div>
+```
+
+## Flexbox grids
+
+You can use [flex utilities](/styleguide/css/utilities/flexbox) on the container and columns to create a flexbox grid.
+
+This can be useful for keeping columns the same height, justifying content and vertically aligning items. The flexbox grid is also great for working with responsive layouts.
+
+```html
+<div class="d-flex flex-column flex-md-row flex-items-center flex-md-items-center">
+  <div class="col-2 d-flex flex-items-center flex-items-center flex-md-items-start">
+    <img class="width-full avatar mb-2 mb-md-0" src="/github.png" alt="github" />
+  </div>
+  <div class="col-12 col-md-10 d-flex flex-column flex-justify-center flex-items-center flex-md-items-start pl-md-4">
+    <h1 class="text-normal lh-condensed">GitHub</h1>
+    <p class="h4 text-gray text-normal mb-2">How people build software.</p>
+    <a class="text-gray text-small" href="#url">https://github.com/about</a>
+  </div>
+</div>
+```
+
+
+## Responsive grids
+All the column width classes can be set per breakpoint to create responsive grid layouts. Each responsive style is applied to the specified breakpoint and up.
+
+### Breakpoints
+We use abbreviations for each breakpoint to keep the class names concise.
+
+| Shorthand | Description |
+| --- | --- |
+| sm | min-width: 544px |
+| md | min-width: 768px |
+| lg | min-width: 1004px |
+| xl | min-width: 1280px |
+
+**Note:** The `lg` breakpoint matches our current page width of `980px` including left and right padding of `12px`. This is so that content doesn't touch the edges of the window when resized.
+
+<hr />
+
+In this example at the `sm` breakpoint 2 columns will show, at the `md` breakpoint 4 columns will show, and at the `lg` breakpoint 6 columns will show.
+
+```html
+<div class="container-lg clearfix">
+  <div class="col-sm-6 col-md-3 col-lg-2 float-left p-2 border">
+    .col-sm-6 .col-md-3 .col-lg-2
+  </div>
+  <div class="col-sm-6 col-md-3 col-lg-2 float-left p-2 border">
+    .col-sm-6 .col-md-3 .col-lg-2
+  </div>
+  <div class="col-sm-6 col-md-3 col-lg-2 float-left p-2 border">
+    .col-sm-6 .col-md-3 .col-lg-2
+  </div>
+  <div class="col-sm-6 col-md-3 col-lg-2 float-left p-2 border">
+    .col-sm-6 .col-md-3 .col-lg-2
+  </div>
+  <div class="col-sm-6 col-md-3 col-lg-2 float-left p-2 border">
+    .col-sm-6 .col-md-3 .col-lg-2
+  </div>
+  <div class="col-sm-6 col-md-3 col-lg-2 float-left p-2 border">
+    .col-sm-6 .col-md-3 .col-lg-2
+  </div>
+</div>
+```
+
+For demonstration, this is how the above example would look at the `sm` breakpoint.
+
+```html
+<div class="container-lg clearfix">
+  <div class="col-sm-6 float-left p-2 border">
+    .col-sm-6
+  </div>
+  <div class="col-sm-6 float-left p-2 border">
+    .col-sm-6
+  </div>
+  <div class="col-sm-6 float-left p-2 border">
+    .col-sm-6
+  </div>
+  <div class="col-sm-6 float-left p-2 border">
+    .col-sm-6
+  </div>
+  <div class="col-sm-6 float-left p-2 border">
+    .col-sm-6
+  </div>
+  <div class="col-sm-6 float-left p-2 border">
+    .col-sm-6
+  </div>
+</div>
+```
+This is how that same example would look at the `md` breakpoint.
+
+```html
+<div class="container-lg clearfix">
+  <div class="col-md-3 float-left p-2 border">
+    .col-md-3
+  </div>
+  <div class="col-md-3 float-left p-2 border">
+    .col-md-3
+  </div>
+  <div class="col-md-3 float-left p-2 border">
+    .col-md-3
+  </div>
+  <div class="col-md-3 float-left p-2 border">
+    .col-md-3
+  </div>
+  <div class="col-md-3 float-left p-2 border">
+    .col-md-3
+  </div>
+  <div class="col-md-3 float-left p-2 border">
+    .col-md-3
+  </div>
+</div>
+```
+
+This is how that example would look at the `lg` breakpoint.
+
+```html
+<div class="container-lg clearfix">
+  <div class="col-lg-2 float-left p-2 border">
+    .col-lg-2
+  </div>
+  <div class="col-lg-2 float-left p-2 border">
+    .col-lg-2
+  </div>
+  <div class="col-lg-2 float-left p-2 border">
+    .col-lg-2
+  </div>
+  <div class="col-lg-2 float-left p-2 border">
+    .col-lg-2
+  </div>
+  <div class="col-lg-2 float-left p-2 border">
+    .col-lg-2
+  </div>
+  <div class="col-lg-2 float-left p-2 border">
+    .col-lg-2
+  </div>
+</div>
+```
+
+## Containers
+Container widths match our breakpoints and are available at a `md`, `lg`, and `xl` size. Containers apply a max-width rather than a fixed width for responsive layouts, and they center the container.
+
+```html
+<div class="container-md border">
+  .container-md, max-width 768px
+</div>
+
+<div class="container-lg border">
+  .container-lg, max-width 1012px
+</div>
+
+<div class="container-xl border">
+  .container-xl, max-width 1280px
+</div>
+```
+
+**Note:** `.container` is being replaced with `.container-lg`. To match the current fixed page width use `.container-lg` with `px-3`. This gives the container padding on smaller screens which works better for responsive layouts.

--- a/modules/primer-layout/package.json
+++ b/modules/primer-layout/package.json
@@ -10,7 +10,8 @@
   "files": [
     "index.scss",
     "lib",
-    "build"
+    "build",
+    "docs"
   ],
   "repository": "https://github.com/primer/primer-css/tree/master/modules/primer-layout",
   "bugs": {

--- a/modules/primer-marketing-utilities/package.json
+++ b/modules/primer-marketing-utilities/package.json
@@ -10,7 +10,8 @@
   "files": [
     "index.scss",
     "lib",
-    "build"
+    "build",
+    "docs"
   ],
   "repository": "https://github.com/primer/primer-css/tree/master/modules/primer-marketing-utilities",
   "bugs": {

--- a/modules/primer-support/README.md
+++ b/modules/primer-support/README.md
@@ -29,7 +29,21 @@ You can also import specific portions of the module by importing those partials 
 
 ## Documentation
 
-You can read more about support in the [docs][docs].
+<!-- %docs
+title: Support
+-->
+
+Primer is built on systems that form the foundation of our styles, and inform the way we write and organize our CSS. Building upon systems helps us make styles consistent and interoperable with each other, and assists us with visual hierarchy and vertical rhythm.
+
+We use Sass variables to keep color, typography, spacing, and other foundations of our system consistent. Occasionally we use Sass mixins to apply multiple CSS properties, they are a convenient solution for frequently-used verbose patterns.
+
+We've documented variables, mixins, and the systems they are built on for the following:
+- [Breakpoints](./support/breakpoints)
+- [Colors](./support/color-system)
+- [Spacing](./support/spacing)
+- [Typography](./support/typography)
+
+<!-- %enddocs -->
 
 ## License
 

--- a/modules/primer-support/docs/breakpoints.md
+++ b/modules/primer-support/docs/breakpoints.md
@@ -1,0 +1,60 @@
+---
+title: Breakpoints
+status: Stable
+source: https://github.com/primer/primer-css/blob/master/modules/primer-support/lib/mixins/layout.scss
+---
+
+{:toc}
+
+Our breakpoints are based on screen widths where our content starts to break. Since most of GitHub is currently a fixed-width with we use pixel widths to make it easy for us to match page widths for responsive and non-responsive pages. **Our breakpoints may change as we move more of the product into responsive layouts.**
+
+We use abbreviations for each breakpoint to keep the class names concise. This abbreviated syntax is used consistently across responsive styles. Responsive styles allow you to change the styles properties at each breakpoint. For example, when using column widths for grid layouts, you can change specify that the width is 12 columns wide at the small breakpoint, and 6 columns wide from the large breakpoint: `<div class="col-sm-12 col-lg-6">...</div>`
+
+| Breakpoint | Syntax | Description |
+| --- | --- | --- |
+| Small | sm | min-width: 544px |
+| Medium | md | min-width: 768px |
+| Large | lg | min-width: 1012px |
+| Extra-large | xl | min-width: 1280px |
+
+<small>**Note:** The `lg` breakpoint matches our current page width of `980px` including left and right padding of `16px` (`$spacer-3`). This is so that content doesn't touch the edges of the window when resized.</small>
+
+Responsive styles are available for [margin](./utilities/margin#responsive-margin), [padding](./utilities/padding#responsive-padding), [layout](./utilities/layout), [flexbox](.utilities/flexbox#responsive-flex-utilities), and the [grid](./objects/grid#responsive-grids) system.
+
+## Breakpoint variables
+
+The above values are defined as variables, and then put into a Sass map that generates the media query mixin.
+
+```scss
+
+// breakpoints
+$width-xs: 0;
+$width-sm: 544px;
+$width-md: 768px;
+$width-lg: 1012px;
+$width-xl: 1280px;
+
+$breakpoints: (
+  // Small screen / phone
+  sm: $width-sm,
+  // Medium screen / tablet
+  md: $width-md,
+  // Large screen / desktop (980 + (12 * 2)) <= container + gutters
+  lg: $width-lg,
+  // Extra large screen / wide desktop
+  xl: $width-xl
+) !default;
+
+```
+
+## Media query mixins
+Use media query mixins when you want to change CSS properties at a particular breakpoint. The media query mixin works by passing in a breakpoint value, such as `breakpoint(md)`.
+
+Media queries are scoped from each breakpoint and upwards. In the example below, the font size is `28px` until the viewport size meets the `lg` breakpoint, from there upwards—including through the `xl` breakpoint—the font size will be `32px`.
+
+```
+.styles {
+  font-size: 28px;
+  @include breakpoint(md) { font-size: 32px; }
+}
+```

--- a/modules/primer-support/docs/color-system.md
+++ b/modules/primer-support/docs/color-system.md
@@ -1,0 +1,392 @@
+---
+title: Color system
+status_issue: https://github.com/github/design-systems/issues/301
+status: New release
+source: https://github.com/primer/primer-css/blob/master/modules/primer-support/lib/variables/color-system.scss
+---
+
+{:toc}
+
+## Color palette
+
+<div class="markdown-no-margin mb-6 d-flex h5">
+  <div class="gray-500 d-flex color-square mr-2">
+    <p class="p-3 flex-self-end text-white">Gray</p>
+  </div>
+  <div class="blue-500 d-flex color-square mr-2">
+    <p class="p-3 flex-self-end text-white">Blue</p>
+  </div>
+  <div class="green-500 d-flex color-square mr-2">
+    <p class="p-3 flex-self-end text-white">Green</p>
+  </div>
+  <div class="purple-500 d-flex color-square mr-2">
+    <p class="p-3 flex-self-end text-white">Purple</p>
+  </div>
+  <div class="yellow-500 d-flex color-square mr-2">
+    <p class="p-3 flex-self-end">Yellow</p>
+  </div>
+  <div class="orange-500 d-flex color-square mr-2">
+    <p class="p-3 flex-self-end">Orange</p>
+  </div>
+  <div class="red-500 d-flex color-square mr-2">
+    <p class="p-3 flex-self-end text-white">Red</p>
+  </div>
+  <div class="bg-white d-flex color-square border border-gray-dark">
+    <p class="p-3 flex-self-end">White</p>
+  </div>
+</div>
+
+## Color variables
+
+<div class="d-flex flex-wrap gutter">
+
+  <div class="mb-6 flex-column col-6 markdown-no-margin">
+    <h3>Gray</h3>
+    <div class="gray-500 my-2 p-3">
+      <p class="text-white f00-light pb-3">Gray</p>
+      <div class="d-flex text-white">
+        <p class="h4 flex-auto">$gray-500</p>
+        <p class="text-right text-mono flex-auto">#6a737d</p>
+      </div>
+    </div>
+    <div class="gray-000 h4">
+      <p class="p-3">$gray-000</p>
+    </div>
+    <div class="gray-100 h4">
+      <p class="p-3">$gray-100</p>
+    </div>
+    <div class="gray-200 h4">
+      <p class="p-3">$gray-200</p>
+    </div>
+    <div class="gray-300 h4">
+      <p class="p-3">$gray-300</p>
+    </div>
+    <div class="gray-400 h4">
+      <p class="p-3">$gray-400</p>
+    </div>
+    <div class="gray-500 h4">
+      <p class="p-3 text-white">$gray-500</p>
+    </div>
+    <div class="gray-600 h4">
+      <p class="p-3 text-white">$gray-600</p>
+    </div>
+    <div class="gray-700 h4">
+      <p class="p-3 text-white">$gray-700</p>
+    </div>
+    <div class="gray-800 h4">
+      <p class="p-3 text-white">$gray-800</p>
+    </div>
+    <div class="gray-900 h4">
+      <p class="p-3 text-white">$gray-900</p>
+    </div>
+  </div>
+
+  <div class="mb-6 flex-column col-6 markdown-no-margin">
+    <h3>Blue</h3>
+    <div class="blue-500 my-2 p-3">
+      <p class="text-white f00-light pb-3">Blue</p>
+      <div class="d-flex text-white">
+        <p class="h4 flex-auto">$blue-500</p>
+        <p class="text-right text-mono flex-auto">#0366d6</p>
+      </div>
+    </div>
+    <div class="blue-000 h4">
+      <p class="p-3">$blue-000</p>
+    </div>
+    <div class="blue-100 h4">
+      <p class="p-3">$blue-100</p>
+    </div>
+    <div class="blue-200 h4">
+      <p class="p-3">$blue-200</p>
+    </div>
+    <div class="blue-300 h4">
+      <p class="p-3">$blue-300</p>
+    </div>
+    <div class="blue-400 h4">
+      <p class="p-3">$blue-400</p>
+    </div>
+    <div class="blue-500 h4">
+      <p class="p-3 text-white">$blue-500</p>
+    </div>
+    <div class="blue-600 h4">
+      <p class="p-3 text-white">$blue-600</p>
+    </div>
+    <div class="blue-700 h4">
+      <p class="p-3 text-white">$blue-700</p>
+    </div>
+    <div class="blue-800 h4">
+      <p class="p-3 text-white">$blue-800</p>
+    </div>
+    <div class="blue-900 h4">
+      <p class="p-3 text-white">$blue-900</p>
+    </div>
+  </div>
+
+  <div class="mb-6 flex-column col-6 markdown-no-margin">
+    <h3>Green</h3>
+    <div class="green-500 my-2 p-3">
+      <p class="text-white f00-light pb-3">Green</p>
+      <div class="d-flex text-white">
+        <p class="h4 flex-auto">$green-500</p>
+        <p class="text-right text-mono flex-auto">#28a745</p>
+      </div>
+    </div>
+    <div class="green-000 h4">
+      <p class="p-3">$green-000</p>
+    </div>
+    <div class="green-100 h4">
+      <p class="p-3">$green-100</p>
+    </div>
+    <div class="green-200 h4">
+      <p class="p-3">$green-200</p>
+    </div>
+    <div class="green-300 h4">
+      <p class="p-3">$green-300</p>
+    </div>
+    <div class="green-400 h4">
+      <p class="p-3">$green-400</p>
+    </div>
+    <div class="green-500 h4">
+      <p class="p-3 text-white">$green-500</p>
+    </div>
+    <div class="green-600 h4">
+      <p class="p-3 text-white">$green-600</p>
+    </div>
+    <div class="green-700 h4">
+      <p class="p-3 text-white">$green-700</p>
+    </div>
+    <div class="green-800 h4">
+      <p class="p-3 text-white">$green-800</p>
+    </div>
+    <div class="green-900 h4">
+      <p class="p-3 text-white">$green-900</p>
+    </div>
+  </div>
+
+  <div class="mb-6 flex-column col-6 markdown-no-margin">
+    <h3>Purple</h3>
+    <div class="purple-500 text-white my-2 p-3">
+      <p class="f00-light pb-3">Purple</p>
+      <div class="d-flex">
+        <p class="h4 flex-auto">$purple-500</p>
+        <p class="text-right text-mono flex-auto">#6f42c1</p>
+      </div>
+    </div>
+    <div class="purple-000 h4">
+      <p class="p-3">$purple-000</p>
+    </div>
+    <div class="purple-100 h4">
+      <p class="p-3">$purple-100</p>
+    </div>
+    <div class="purple-200 h4">
+      <p class="p-3">$purple-200</p>
+    </div>
+    <div class="purple-300 h4">
+      <p class="p-3">$purple-300</p>
+    </div>
+    <div class="purple-400 h4">
+      <p class="p-3">$purple-400</p>
+    </div>
+    <div class="purple-500 h4">
+      <p class="p-3 text-white">$purple-500</p>
+    </div>
+    <div class="purple-600 h4">
+      <p class="p-3 text-white">$purple-600</p>
+    </div>
+    <div class="purple-700 h4">
+      <p class="p-3 text-white">$purple-700</p>
+    </div>
+    <div class="purple-800 h4">
+      <p class="p-3 text-white">$purple-800</p>
+    </div>
+    <div class="purple-900 h4">
+      <p class="p-3 text-white">$purple-900</p>
+    </div>
+  </div>
+
+  <div class="mb-6 flex-column col-6 markdown-no-margin">
+    <h3>Yellow</h3>
+    <div class="yellow-500 my-2 p-3">
+      <p class="f00-light pb-3">Yellow</p>
+      <div class="d-flex">
+        <p class="h4 flex-auto">$yellow-500</p>
+        <p class="text-right text-mono flex-auto">#ffd93d</p>
+      </div>
+    </div>
+    <div class="yellow-000 h4">
+      <p class="p-3">$yellow-000</p>
+    </div>
+    <div class="yellow-100 h4">
+      <p class="p-3">$yellow-100</p>
+    </div>
+    <div class="yellow-200 h4">
+      <p class="p-3">$yellow-200</p>
+    </div>
+    <div class="yellow-300 h4">
+      <p class="p-3">$yellow-300</p>
+    </div>
+    <div class="yellow-400 h4">
+      <p class="p-3">$yellow-400</p>
+    </div>
+    <div class="yellow-500 h4">
+      <p class="p-3">$yellow-500</p>
+    </div>
+    <div class="yellow-600 h4">
+      <p class="p-3">$yellow-600</p>
+    </div>
+    <div class="yellow-700 h4">
+      <p class="p-3">$yellow-700</p>
+    </div>
+    <div class="yellow-800 h4">
+      <p class="p-3 text-white">$yellow-800</p>
+    </div>
+    <div class="yellow-900 h4">
+      <p class="p-3 text-white">$yellow-900</p>
+    </div>
+  </div>
+
+  <div class="mb-6 flex-column col-6 markdown-no-margin">
+    <h3>Orange</h3>
+    <div class="orange-500 my-2 p-3 text-white">
+      <p class="f00-light pb-3">Orange</p>
+      <div class="d-flex">
+        <p class="h4 flex-auto">$orange-500</p>
+        <p class="text-right text-mono flex-auto">#f66a0a</p>
+      </div>
+    </div>
+    <div class="orange-000 h4">
+      <p class="p-3">$orange-000</p>
+    </div>
+    <div class="orange-100 h4">
+      <p class="p-3">$orange-100</p>
+    </div>
+    <div class="orange-200 h4">
+      <p class="p-3">$orange-200</p>
+    </div>
+    <div class="orange-300 h4">
+      <p class="p-3">$orange-300</p>
+    </div>
+    <div class="orange-400 h4">
+      <p class="p-3">$orange-400</p>
+    </div>
+    <div class="orange-500 h4">
+      <p class="p-3 text-white">$orange-500</p>
+    </div>
+    <div class="orange-600 h4">
+      <p class="p-3 text-white">$orange-600</p>
+    </div>
+    <div class="orange-700 h4">
+      <p class="p-3 text-white">$orange-700</p>
+    </div>
+    <div class="orange-800 h4">
+      <p class="p-3 text-white">$orange-800</p>
+    </div>
+    <div class="orange-900 h4">
+      <p class="p-3 text-white">$orange-900</p>
+    </div>
+  </div>
+
+  <div class="mb-6 flex-column col-6 markdown-no-margin">
+    <h3>Red</h3>
+    <div class="red-500 text-white my-2 p-3">
+      <p class="f00-light pb-3">Red</p>
+      <div class="d-flex">
+        <p class="h4 flex-auto">$red-500</p>
+        <p class="text-right text-mono flex-auto">#dc3545</p>
+      </div>
+    </div>
+    <div class="red-000 h4">
+      <p class="p-3">$red-000</p>
+    </div>
+    <div class="red-100 h4">
+      <p class="p-3">$red-100</p>
+    </div>
+    <div class="red-200 h4">
+      <p class="p-3">$red-200</p>
+    </div>
+    <div class="red-300 h4">
+      <p class="p-3">$red-300</p>
+    </div>
+    <div class="red-400 h4">
+      <p class="p-3">$red-400</p>
+    </div>
+    <div class="red-500 h4">
+      <p class="p-3 text-white">$red-500</p>
+    </div>
+    <div class="red-600 h4">
+      <p class="p-3 text-white">$red-600</p>
+    </div>
+    <div class="red-700 h4">
+      <p class="p-3 text-white">$red-700</p>
+    </div>
+    <div class="red-800 h4">
+      <p class="p-3 text-white">$red-800</p>
+    </div>
+    <div class="red-900 h4">
+      <p class="p-3 text-white">$red-900</p>
+    </div>
+  </div>
+
+<div class="mb-6 flex-column col-6">
+</div>
+  <!-- Gray and fades (headings inside the markup) -->
+
+  <div class="mb-3 flex-column col-6 markdown-no-margin">
+    <h3>Black fades</h3>
+    <div class="black text-white my-2 p-3">
+      <p class="f00-light pb-3">Black</p>
+      <div class="d-flex pb-1">
+        <p class="h4 flex-auto">$black</p>
+        <p class="text-right text-mono flex-auto"><code>rgb(27,31,35)</code> #1b1f23</p>
+      </div>
+      <p class="f5 pt-3 border-top border-white">Black fades apply alpha transparency to the <strong>$black</strong> variable. The black color value has a slight blue hue to match our grays.</p>
+    </div>
+    <div class="black-fade-15">
+      <p class="h4 p-3">$black-fade-15</p>
+    </div>
+    <div class="black-fade-30">
+      <p class="h4 p-3">$black-fade-30</p>
+    </div>
+    <div class="black-fade-50">
+      <p class="h4 p-3">$black-fade-50</p>
+    </div>
+    <div class="black-fade-70">
+      <p class="h4 p-3 text-white">$black-fade-70</p>
+    </div>
+    <div class="black-fade-85">
+      <p class="h4 p-3 text-white">$black-fade-85</p>
+    </div>
+  </div>
+
+  <div class="mb-3 flex-column col-6 markdown-no-margin">
+    <h3>White fades</h3>
+    <div class="bg-white border text-gray-dark my-2 p-3">
+      <p class="f00-light pb-3">White</p>
+      <div class="d-flex pb-1">
+        <p class="h4 flex-auto">$white</p>
+        <p class="text-right text-mono flex-auto"><code>rgb(255, 255, 255)</code> #fff</p>
+      </div>
+      <p class="f5 pt-3 border-top border-white">White fades apply alpha transparency to the <strong>$white</strong> variable, below these are shown overlaid on a dark gray background.</p>
+    </div>
+    <div class="bg-gray-dark pr-4">
+      <div class="white-fade-15">
+        <p class="h4 p-3 text-white">$white-fade-15</p>
+      </div>
+      <div class="white-fade-30">
+        <p class="h4 p-3 text-white">$white-fade-30</p>
+      </div>
+      <div class="white-fade-50">
+        <p class="h4 p-3">$white-fade-50</p>
+      </div>
+      <div class="white-fade-70">
+        <p class="h4 p-3">$white-fade-70</p>
+      </div>
+      <div class="white-fade-85">
+        <p class="h4 p-3">$white-fade-85</p>
+      </div>
+    </div>
+
+
+</div>
+
+</div>

--- a/modules/primer-support/docs/spacing.md
+++ b/modules/primer-support/docs/spacing.md
@@ -1,0 +1,50 @@
+---
+title: Spacing
+status: Stable
+source: https://github.com/primer/primer-css/blob/master/modules/primer-support/lib/variables/layout.scss
+---
+
+{:toc}
+
+## Spacing scale
+The spacing scale is a **base-8** scale. We chose a base-8 scale because eight is a highly composable number (it can be divided and multiplied many times and result in whole numbers), yet allows spacing dense enough for GitHub's UI. The scale's exception is that it begins at 4px to allow smaller padding and margin for denser parts of the site, from there on it steps up consistently in equal values of `8px`.
+
+| Scale | Value |
+| --- | --- |
+| 0 | 0 |
+| 1 | 4px |
+| 2 | 8px |
+| 3 | 16px |
+| 4 | 24px |
+| 5 | 32px |
+| 6 | 40px |
+
+The spacing scale is used for [margin](./utilities/margin) and [padding](./utilities/padding) utilities, and via variables within components.
+
+## Em-based spacing
+Ems are used for spacing within components such as buttons and form elements. We stick to common fractions for em values so that, in combination with typography and line-height, the total height lands on sensible numbers.
+
+We aim for whole numbers, however, GitHub's body font-size is 14px which is difficult to work with, so we sometimes can't achieve a whole number. Less desirable values are highlighted in <span class="text-red">red</span> below.
+
+| Fraction | Y Padding (em) | Total height at 14px | Total height at 16px |
+| --- | --- | --- | --- |
+| 3/4 | .75 | 42 | 48 |
+| 1/2 | .5 | 35 | 40 |
+| 3/8 | .375 | <span class="text-red">31.5</span> | 36 |
+| 1/4 | .25 | 28 | 32 |
+| 1/8 | .125 | <span class="text-red">24.5</span> | 28 |
+
+We recommend using the fractions shown above. To calculate values with other font-sizes or em values, we suggest using [Formula](http://jxnblk.com/formula/).
+
+## Spacer Variables
+
+These variables match the above scale and are encouraged to be used within components. They are also used in our [margin](./utilities/margin) and [padding utilities](./utilities/padding).
+
+```scss
+$spacer-1: 4px;
+$spacer-2: 8px;
+$spacer-3: 16px;
+$spacer-4: 24px;
+$spacer-5: 32px;
+$spacer-6: 40px;
+```

--- a/modules/primer-support/docs/typography.md
+++ b/modules/primer-support/docs/typography.md
@@ -1,0 +1,90 @@
+---
+title: Typography
+status_issue: https://github.com/github/design-systems/issues/329
+status: New release
+source: https://github.com/primer/primer-css/blob/master/modules/primer-support/lib/variables/typography.scss
+---
+
+{:toc}
+
+## Type Scale
+
+The typography scale is designed to work for GitHub's product UI and marketing sites. Font sizes are designed to work in combination with line-height values so as to result in more sensible numbers wherever possible.
+
+Font sizes are smaller on mobile and scale up at the `md` [breakpoint](#breakpoints) to be larger on desktop.
+
+| Scale | Font size: mobile | Font size: desktop | 1.25 line height | 1.5 line height |
+| --- | --- | --- | --- | --- |
+| 00 | 40px | 48px | 60 | 72 |
+| 0 | 32px | 40px | 50 | 60 |
+| 1 | 26px | 32px | 40 | 48 |
+| 2 | 22px | 24px | 30 | 36 |
+| 3 | 18px | 20px | 25 | 30 |
+| 4 | 16px | 16px | 20 | 24 |
+| 5 | 14px | 14px | 17.5 | 21 |
+| 6 | 12px | 12px | 15 | 18 |
+
+The typography scale is used to create [typography utilities](./utilities/typography).
+
+## Typography variables
+
+#### Font size variables
+```scss
+// Heading sizes - mobile
+// h4—h6 remain the same size on both mobile & desktop
+$h00-size-mobile: 40px;
+$h0-size-mobile: 32px;
+$h1-size-mobile: 26px;
+$h2-size-mobile: 22px;
+$h3-size-mobile: 18px;
+
+// Heading sizes - desktop
+$h00-size: 48px;
+$h0-size: 40px;
+$h1-size: 32px;
+$h2-size: 24px;
+$h3-size: 20px;
+$h4-size: 16px;
+$h5-size: 14px;
+$h6-size: 12px;
+```
+
+#### Font weight variables
+```scss
+$font-weight-bold: 600 !default;
+$font-weight-light: 300 !default;
+```
+
+#### Line height variables
+```scss
+$lh-condensed-ultra: 1 !default;
+$lh-condensed: 1.25 !default;
+$lh-default: 1.5 !default;
+```
+
+## Typography Mixins
+Typography mixins are available for heading styles and for our type scale. They can be used within components or custom CSS. The same styles are also available as [utilities](./utilities/typography#heading-utilities) which requires no additional CSS.
+
+Heading mixins are available for `h1` through to `h6`, this includes the font-size and font-weight. Example:
+
+```scss
+.styles {
+  @include h1;
+}
+```
+
+Responsive heading mixins can be used to adjust the font-size between the `sm` and `lg` breakpoint. Only headings 1—3 are responsive. Heading 4—6 are small enough to remain the same between mobile and desktop. Responsive heading mixins include the font-size and font-weight as well as the media query. To use a responsive heading mixin, postfix the heading with `-responsive`:
+
+```scss
+.styles {
+  @include h1-responsive;
+}
+```
+
+Responsive type scale mixins are also available. Type scale mixins apply a font-size that gets slightly bigger at the `lg` breakpoint. They do not apply a font-weight. Like the responsive heading mixins, they are only available for size `f1` to `f3` and are postfixed with `-responsive` as in the example below:
+
+```scss
+.style {
+  @include f1-responsive;
+}
+```

--- a/modules/primer-support/package.json
+++ b/modules/primer-support/package.json
@@ -8,7 +8,8 @@
   "style": "index.scss",
   "files": [
     "index.scss",
-    "lib"
+    "lib",
+    "docs"
   ],
   "repository": "https://github.com/primer/primer-css/tree/master/modules/primer-support",
   "bugs": {

--- a/modules/primer-utilities/package.json
+++ b/modules/primer-utilities/package.json
@@ -10,7 +10,8 @@
   "files": [
     "index.scss",
     "lib",
-    "build"
+    "build",
+    "docs"
   ],
   "repository": "https://github.com/primer/primer-css/tree/master/modules/primer-utilities",
   "bugs": {


### PR DESCRIPTION
This moves the following docs from the styleguide to their respective primer module:

- grid
- support 
- support sub-pages: breakpoints, color system, spacing, typography

And also adds `docs` to the `files` key in the `package.json` for:
- utilities
- marketing-utilities
- grid
- support

cc @ds-core 