### PR TITLE
Primer categories and types

### DIFF
--- a/modules/primer-alerts/package.json
+++ b/modules/primer-alerts/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "product",
+    "module_type": "components"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-avatars/package.json
+++ b/modules/primer-avatars/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "product",
+    "module_type": "components"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-base/package.json
+++ b/modules/primer-base/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "core",
+    "module_type": "support"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-blankslate/package.json
+++ b/modules/primer-blankslate/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "product",
+    "module_type": "component"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-blankslate/package.json
+++ b/modules/primer-blankslate/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "primer": {
     "category": "product",
-    "module_type": "component"
+    "module_type": "components"
   },
   "files": [
     "index.scss",

--- a/modules/primer-box/package.json
+++ b/modules/primer-box/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "core",
+    "module_type": "components"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-breadcrumb/package.json
+++ b/modules/primer-breadcrumb/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "primer": {
     "category": "marketing",
-    "module_type": "component"
+    "module_type": "components"
   },
   "files": [
     "index.scss",

--- a/modules/primer-breadcrumb/package.json
+++ b/modules/primer-breadcrumb/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "build/build.css",
   "main": "build/index.js",
+  "primer": {
+    "category": "marketing",
+    "module_type": "component"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-buttons/package.json
+++ b/modules/primer-buttons/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "core",
+    "module_type": "components"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-cards/package.json
+++ b/modules/primer-cards/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "primer": {
     "category": "marketing",
-    "module_type": "component"
+    "module_type": "components"
   },
   "files": [
     "index.scss",

--- a/modules/primer-cards/package.json
+++ b/modules/primer-cards/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "build/build.css",
   "main": "build/index.js",
+  "primer": {
+    "category": "marketing",
+    "module_type": "component"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-core/package.json
+++ b/modules/primer-core/package.json
@@ -7,6 +7,9 @@
   "license": "MIT",
   "style": "build/build.css",
   "main": "build/index.js",
+  "primer": {
+    "category": "core"
+  },
   "files": [
     "index.scss",
     "build"

--- a/modules/primer-forms/package.json
+++ b/modules/primer-forms/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "core",
+    "module_type": "components"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-labels/package.json
+++ b/modules/primer-labels/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "product",
+    "module_type": "components"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-layout/package.json
+++ b/modules/primer-layout/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "primer": {
     "category": "core",
-    "module_type": "object"
+    "module_type": "objects"
   },
   "files": [
     "index.scss",

--- a/modules/primer-layout/package.json
+++ b/modules/primer-layout/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "core",
+    "module_type": "object"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-markdown/package.json
+++ b/modules/primer-markdown/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "product",
+    "module_type": "component"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-markdown/package.json
+++ b/modules/primer-markdown/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "primer": {
     "category": "product",
-    "module_type": "component"
+    "module_type": "components"
   },
   "files": [
     "index.scss",

--- a/modules/primer-marketing-support/package.json
+++ b/modules/primer-marketing-support/package.json
@@ -6,6 +6,10 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "index.scss",
+  "primer": {
+    "category": "marketing",
+    "module_type": "support"
+  },
   "files": [
     "index.scss",
     "lib"

--- a/modules/primer-marketing-type/package.json
+++ b/modules/primer-marketing-type/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "build/build.css",
   "main": "build/index.js",
+  "primer": {
+    "category": "marketing",
+    "module_type": "utilities"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-marketing-utilities/package.json
+++ b/modules/primer-marketing-utilities/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "marketing",
+    "module_type": "utilities"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-marketing/package.json
+++ b/modules/primer-marketing/package.json
@@ -7,6 +7,9 @@
   "license": "MIT",
   "style": "build/build.css",
   "main": "build/index.js",
+  "primer": {
+    "category": "marketing"
+  },
   "files": [
     "index.scss",
     "build"

--- a/modules/primer-navigation/package.json
+++ b/modules/primer-navigation/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "core",
+    "module_type": "component"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-navigation/package.json
+++ b/modules/primer-navigation/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "primer": {
     "category": "core",
-    "module_type": "component"
+    "module_type": "components"
   },
   "files": [
     "index.scss",

--- a/modules/primer-page-headers/package.json
+++ b/modules/primer-page-headers/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "primer": {
     "category": "marketing",
-    "module_type": "component"
+    "module_type": "components"
   },
   "files": [
     "index.scss",

--- a/modules/primer-page-headers/package.json
+++ b/modules/primer-page-headers/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "build/build.css",
   "main": "build/index.js",
+  "primer": {
+    "category": "marketing",
+    "module_type": "component"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-page-sections/package.json
+++ b/modules/primer-page-sections/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "primer": {
     "category": "marketing",
-    "module_type": "component"
+    "module_type": "components"
   },
   "files": [
     "index.scss",

--- a/modules/primer-page-sections/package.json
+++ b/modules/primer-page-sections/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "build/build.css",
   "main": "build/index.js",
+  "primer": {
+    "category": "marketing",
+    "module_type": "component"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-product/package.json
+++ b/modules/primer-product/package.json
@@ -7,6 +7,9 @@
   "license": "MIT",
   "style": "build/build.css",
   "main": "build/index.js",
+  "primer": {
+    "category": "product"
+  },
   "files": [
     "index.scss",
     "build"

--- a/modules/primer-support/package.json
+++ b/modules/primer-support/package.json
@@ -6,6 +6,10 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "index.scss",
+  "primer": {
+    "category": "core",
+    "module_type": "support"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-table-object/package.json
+++ b/modules/primer-table-object/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "primer": {
     "category": "core",
-    "module_type": "object"
+    "module_type": "objects"
   },
   "files": [
     "index.scss",

--- a/modules/primer-table-object/package.json
+++ b/modules/primer-table-object/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "core",
+    "module_type": "object"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-tables/package.json
+++ b/modules/primer-tables/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "primer": {
     "category": "marketing",
-    "module_type": "component"
+    "module_type": "components"
   },
   "files": [
     "index.scss",

--- a/modules/primer-tables/package.json
+++ b/modules/primer-tables/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "build/build.css",
   "main": "build/index.js",
+  "primer": {
+    "category": "marketing",
+    "module_type": "component"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-tooltips/package.json
+++ b/modules/primer-tooltips/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "core",
+    "module_type": "component"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-tooltips/package.json
+++ b/modules/primer-tooltips/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "primer": {
     "category": "core",
-    "module_type": "component"
+    "module_type": "components"
   },
   "files": [
     "index.scss",

--- a/modules/primer-truncate/package.json
+++ b/modules/primer-truncate/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "core",
+    "module_type": "component"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-truncate/package.json
+++ b/modules/primer-truncate/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "primer": {
     "category": "core",
-    "module_type": "component"
+    "module_type": "components"
   },
   "files": [
     "index.scss",

--- a/modules/primer-utilities/package.json
+++ b/modules/primer-utilities/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "style": "index.scss",
   "main": "build/index.js",
+  "primer": {
+    "category": "core",
+    "module_type": "utilities"
+  },
   "files": [
     "index.scss",
     "lib",


### PR DESCRIPTION
This pr adds primer categories and types to each modules package.json.

- Categories map directly to our meta-packages: `primer-core`, `primer-product`, and `primer-marketing.
- Module types map to our style types: support, utilities, objects, and components.

We're adding these to help us pulling in metadata and organizing navigation in the new style guide docs, and because we think this information will be helpful for capturing stages in the future.

cc @ds-core