### PR TITLE
Add comments to direction classes

### DIFF
--- a/modules/primer-utilities/lib/layout.scss
+++ b/modules/primer-utilities/lib/layout.scss
@@ -81,14 +81,15 @@
 .min-width-0 { min-width: 0 !important; }
 
 // Direction utilities
-
+/* Set the direction to rtl */
 .direction-rtl { direction: rtl !important; }
 
+/* Set the direction to ltr */
 .direction-ltr { direction: ltr !important; }
 
 @each $breakpoint in map-keys($breakpoints) {
   @include breakpoint($breakpoint) {
-    /* Set the direction to ltr at the #{$breakpoint} breakpoint */
+    /* Set the direction to rtl at the #{$breakpoint} breakpoint */
     .direction-#{$breakpoint}-rtl { direction: rtl !important; }
     /* Set the direction to ltr at the #{$breakpoint} breakpoint */
     .direction-#{$breakpoint}-ltr { direction: ltr !important; }


### PR DESCRIPTION
Add comments to the `.direction-rtl` and `.direction-ltr` classes, and fix the comment for the `direction-#{$breakpoint}-rtl` classes.

cc @primer/ds-core