### PR TITLE
Add module_type: "meta" to css, core, marketing, & product

### DIFF
--- a/modules/primer-core/package.json
+++ b/modules/primer-core/package.json
@@ -8,7 +8,8 @@
   "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
-    "category": "core"
+    "category": "core",
+    "module_type": "meta"
   },
   "files": [
     "index.scss",

--- a/modules/primer-css/package.json
+++ b/modules/primer-css/package.json
@@ -6,6 +6,9 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "style": "build/build.css",
+  "primer": {
+    "module_type": "meta"
+  },
   "files": [
     "index.scss",
     "lib",

--- a/modules/primer-marketing/package.json
+++ b/modules/primer-marketing/package.json
@@ -8,7 +8,8 @@
   "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
-    "category": "marketing"
+    "category": "marketing",
+    "module_type": "meta"
   },
   "files": [
     "index.scss",

--- a/modules/primer-product/package.json
+++ b/modules/primer-product/package.json
@@ -8,7 +8,8 @@
   "style": "build/build.css",
   "main": "build/index.js",
   "primer": {
-    "category": "product"
+    "category": "product",
+    "module_type": "meta"
   },
   "files": [
     "index.scss",


### PR DESCRIPTION
This sets `primer.module_type` to `meta` in all of our meta-packages: `primer-css`, `-core`, `-marketing`, and `-product`. Currently these values live in the styleguide's YAML file, and we can remove them from there once this gets released.

/cc @primer/ds-core
