### PR TITLE
Add fill-inherit utility class

### DIFF
--- a/modules/primer-utilities/lib/colors.scss
+++ b/modules/primer-utilities/lib/colors.scss
@@ -62,6 +62,9 @@
 /* Set the text color to inherit */
 .text-inherit       { color: inherit !important; }
 
+/* Fill SVGs (such as octicons) with the current text color */
+.fill-inherit { fill: currentColor; }
+
 // Text states
 // These can probably all be regular utilities
 .text-pending { color: $yellow-800 !important; }


### PR DESCRIPTION
This adds a `fill-inherit` utility class that sets `fill: currentColor`, which is particularly useful for inline SVG that you want to "inherit" whatever CSS `color` value its adjacent text has (including `:hover` styles).

With this, you can avoid having to double up on classes like `text-blue fill-blue` and use `text-blue fill-inherit` instead, and allow octicons to inherit the link color without having to explicitly specify `fill-blue`, which saves us some refactoring later when links become purple. :trollface: 

This probably can't be part of #329, since merging it will prompt a version bump from Lerna. So maybe we release 9.4 then queue this up for 9.5?

### TODO
- [ ] Add docs (after getting feedback)

/cc @primer/design-systems 
