### PR TITLE
Import dropdown component

### DIFF
--- a/modules/primer-alerts/LICENSE
+++ b/modules/primer-alerts/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-avatars/LICENSE
+++ b/modules/primer-avatars/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-base/LICENSE
+++ b/modules/primer-base/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-blankslate/LICENSE
+++ b/modules/primer-blankslate/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-box/LICENSE
+++ b/modules/primer-box/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-breadcrumb/LICENSE
+++ b/modules/primer-breadcrumb/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-buttons/LICENSE
+++ b/modules/primer-buttons/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-cards/LICENSE
+++ b/modules/primer-cards/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-core/LICENSE
+++ b/modules/primer-core/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-css/LICENSE
+++ b/modules/primer-css/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-css/package.json
+++ b/modules/primer-css/package.json
@@ -34,6 +34,7 @@
     "primer-buttons": "2.3.0",
     "primer-cards": "0.4.0",
     "primer-core": "6.3.0",
+    "primer-dropdown": "1.0.0",
     "primer-forms": "1.3.0",
     "primer-labels": "1.4.0",
     "primer-layout": "1.3.0",

--- a/modules/primer-css/package.json
+++ b/modules/primer-css/package.json
@@ -34,7 +34,7 @@
     "primer-buttons": "2.3.0",
     "primer-cards": "0.4.0",
     "primer-core": "6.3.0",
-    "primer-dropdown": "1.0.0",
+    "primer-dropdown": "0.1.0",
     "primer-forms": "1.3.0",
     "primer-labels": "1.4.0",
     "primer-layout": "1.3.0",

--- a/modules/primer-dropdown/.npmignore
+++ b/modules/primer-dropdown/.npmignore
@@ -1,0 +1,2 @@
+*.yml
+.github

--- a/modules/primer-dropdown/LICENSE
+++ b/modules/primer-dropdown/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/modules/primer-dropdown/LICENSE
+++ b/modules/primer-dropdown/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-dropdown/README.md
+++ b/modules/primer-dropdown/README.md
@@ -36,22 +36,208 @@ $ npm run build
 ## Documentation
 
 <!-- %docs
-title: Table object
+title: Dropdown
 status: Stable
-key: /css/styles/core/objects/dropdown
+source: https://github.com/github/github/blob/master/app/assets/stylesheets/components/dropdown.scss
 -->
 
-The table object is a module for creating dynamically resizable elements that always sit on the same horizontal line (e.g., they never break to a new line). Using table styles in our CSS means it's cross browser friendly back to at least IE9.
+Dropdowns are lightweight, JavaScript-powered context menus for housing navigation and actions. They're great for instances where you don't need the full power (and code) of the select menu.
 
-Additional `margin` or `padding` may be required to properly space content.
+{:toc}
+
+## Basic examples
+
+Dropdowns should be trigged by a `<button>`. **[Each dropdown menu requires a directional class](#alignment)**, much like our tooltips.
+
+Using a GitHub button:
 
 ```html
-<div class="TableObject">
-  <div class="TableObject-item TableObject-item--primary">
-    <input class="input-block form-control" type="text" placeholder="Long elastic input form" aria-label="Long elastic input form">
+<div class="dropdown js-menu-container js-select-menu">
+  <button class="btn dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
+    Dropdown
+    <div class="dropdown-caret"></div>
+  </button>
+
+  <div class="dropdown-menu-content js-menu-content">
+    <ul class="dropdown-menu dropdown-menu-se">
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+    </ul>
   </div>
-  <div class="TableObject-item">
-    <button class="btn ml-2" type="button">Button</button>
+</div>
+```
+
+Using a button customized with additional utilities:
+
+
+```html
+<div class="dropdown js-menu-container js-select-menu">
+  <button class="btn-link no-underline text-gray p-2 dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
+    Dropdown
+    <div class="dropdown-caret"></div>
+  </button>
+
+  <div class="dropdown-menu-content js-menu-content">
+    <ul class="dropdown-menu dropdown-menu-se">
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+    </ul>
+  </div>
+</div>
+```
+
+## Options
+
+### Alignment
+
+Align the direction of dropdown menus and their arrows with modifier classes.
+
+```html
+<div class="dropdown js-menu-container js-select-menu">
+  <button class="btn dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
+    .dropdown-ne
+    <div class="dropdown-caret"></div>
+  </button>
+
+  <div class="dropdown-menu-content js-menu-content">
+    <ul class="dropdown-menu dropdown-menu-ne">
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+    </ul>
+  </div>
+</div>
+```
+
+```html
+<div class="dropdown float-right js-menu-container js-select-menu">
+  <button class="btn dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
+    .dropdown-e
+    <div class="dropdown-caret"></div>
+  </button>
+
+  <div class="dropdown-menu-content js-menu-content">
+    <ul class="dropdown-menu dropdown-menu-e">
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+    </ul>
+  </div>
+</div>
+```
+
+```html
+<div class="dropdown js-menu-container js-select-menu">
+  <button class="btn dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
+    .dropdown-se
+    <div class="dropdown-caret"></div>
+  </button>
+
+  <div class="dropdown-menu-content js-menu-content">
+    <ul class="dropdown-menu dropdown-menu-se">
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+    </ul>
+  </div>
+</div>
+```
+
+```html
+<div class="dropdown d-inline-block mx-auto js-menu-container js-select-menu">
+  <button class="btn dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
+    .dropdown-s
+    <div class="dropdown-caret"></div>
+  </button>
+
+  <div class="dropdown-menu-content js-menu-content">
+    <ul class="dropdown-menu dropdown-menu-s">
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+    </ul>
+  </div>
+</div>
+```
+
+```html
+<div class="dropdown float-right js-menu-container js-select-menu">
+  <button class="btn dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
+    .dropdown-sw
+    <div class="dropdown-caret"></div>
+  </button>
+
+  <div class="dropdown-menu-content js-menu-content">
+    <ul class="dropdown-menu dropdown-menu-sw">
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+    </ul>
+  </div>
+</div>
+```
+
+```html
+<div class="dropdown js-menu-container js-select-menu">
+  <button class="btn dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
+    .dropdown-w
+    <div class="dropdown-caret"></div>
+  </button>
+
+  <div class="dropdown-menu-content js-menu-content">
+    <ul class="dropdown-menu dropdown-menu-w">
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+    </ul>
+  </div>
+</div>
+```
+
+### Dividers
+
+```html
+<div class="dropdown js-menu-container js-select-menu">
+  <button class="btn dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
+    Dropdown
+    <div class="dropdown-caret"></div>
+  </button>
+
+  <div class="dropdown-menu-content js-menu-content">
+    <ul class="dropdown-menu dropdown-menu-se">
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li class="dropdown-divider" role="separator"></li>
+      <li><a class="dropdown-item" href="#url">Another item</a></li>
+      <li><a class="dropdown-item" href="#url">One more</a></li>
+    </ul>
+  </div>
+</div>
+```
+
+### Headers
+
+```html
+<div class="dropdown js-menu-container js-select-menu">
+  <button class="btn dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
+    Dropdown
+    <div class="dropdown-caret"></div>
+  </button>
+
+  <div class="dropdown-menu-content js-menu-content">
+    <div class="dropdown-menu dropdown-menu-se">
+      <div class="dropdown-header">
+        Dropdown header
+      </div>
+      <ul>
+        <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+        <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+        <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      </ul>
+    </div>
   </div>
 </div>
 ```

--- a/modules/primer-dropdown/README.md
+++ b/modules/primer-dropdown/README.md
@@ -1,0 +1,69 @@
+# Primer CSS table object
+
+[![npm version](http://img.shields.io/npm/v/primer-dropdown.svg)](https://www.npmjs.org/package/primer-dropdown)
+[![Build Status](https://travis-ci.org/primer/primer-css.svg?branch=master)](https://travis-ci.org/primer/primer-css)
+
+> Table object is a module for creating dynamically resizable elements that always sit on the same horizontal line (e.g., they never break to a new line). Using table styles in our CSS means it’s cross browser friendly back to at least IE9.
+
+This repository is a module of the full [primer-css][primer-css] repository.
+
+## Install
+
+This repository is distributed with [npm][npm]. After [installing npm][install-npm], you can install `primer-dropdown` with this command.
+
+```
+$ npm install --save primer-dropdown
+```
+
+## Usage
+
+The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+
+```scss
+@import "primer-dropdown/index.scss";
+```
+
+You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
+
+## Build
+
+For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
+
+```
+$ npm run build
+```
+
+## Documentation
+
+<!-- %docs
+title: Table object
+status: Stable
+key: /css/styles/core/objects/dropdown
+-->
+
+The table object is a module for creating dynamically resizable elements that always sit on the same horizontal line (e.g., they never break to a new line). Using table styles in our CSS means it's cross browser friendly back to at least IE9.
+
+Additional `margin` or `padding` may be required to properly space content.
+
+```html
+<div class="TableObject">
+  <div class="TableObject-item TableObject-item--primary">
+    <input class="input-block form-control" type="text" placeholder="Long elastic input form" aria-label="Long elastic input form">
+  </div>
+  <div class="TableObject-item">
+    <button class="btn ml-2" type="button">Button</button>
+  </div>
+</div>
+```
+
+<!-- %enddocs -->
+
+## License
+
+[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+
+[primer-css]: https://github.com/primer/primer
+[docs]: http://primercss.io/
+[npm]: https://www.npmjs.com/
+[install-npm]: https://docs.npmjs.com/getting-started/installing-node
+[sass]: http://sass-lang.com/

--- a/modules/primer-dropdown/README.md
+++ b/modules/primer-dropdown/README.md
@@ -241,18 +241,21 @@ Align the direction of dropdown menus and their arrows with modifier classes.
 
 ### No overflow
 
+Use `dropdown-menu-no-overflow` modifier class to set the width of the dropdown
+to `auto` and prevent hidden overflows on item contents and text.
+
 ```html
-<div class="select-all-dropdown dropdown js-menu-container js-bulk-actions float-left js-transitionable active">
-  <button class="btn btn-sm mr-3 js-menu-target selected" type="button" aria-expanded="true" aria-haspopup="true">
+<div class="select-all-dropdown dropdown js-menu-container js-bulk-actions float-left js-transitionable">
+  <button class="btn btn-sm mr-3 js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
     1 member selected…
     <span class="dropdown-caret"></span>
   </button>
   <div class="dropdown-menu-content js-menu-content">
     <ul class="dropdown-menu dropdown-menu-no-overflow dropdown-menu-se">
-      <a href="#change-role-54012" rel="facebox[.change-role-54012]" class="dropdown-item js-menu-close">
+      <a href="#url" class="dropdown-item js-menu-close">
         Change role...
       </a>
-      <a href="#remove-team-members-54012" class="dropdown-item menu-item-danger js-menu-close">
+      <a href="#url" class="dropdown-item menu-item-danger js-menu-close">
         Remove from team
       </a>
     </ul>
@@ -262,30 +265,35 @@ Align the direction of dropdown menus and their arrows with modifier classes.
 
 ### Sign out button
 
+Use `<button class="dropdown-item dropdown-signout">` to reset button styles
+and display it as a link.
+
 ```html
-<div class="dropdown js-menu-container">
+<div class="dropdown js-menu-container float-right position-relative">
   <button class="btn dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
     <img alt="@shawnbot" class="avatar" src="https://avatars0.githubusercontent.com/u/113896?v=4&amp;s=40" height="20" width="20">
   </button>
-  <ul class="dropdown-menu dropdown-menu-sw">
-    <li class="dropdown-header header-nav-current-user css-truncate">
+  <div class="dropdown-menu-content js-menu-content">
+    <ul class="dropdown-menu dropdown-menu-sw">
+      <li class="dropdown-header header-nav-current-user css-truncate">
       Signed in as <strong class="css-truncate-target">shawnbot</strong>
-    </li>
-    <li class="dropdown-divider"></li>
-    <li><a class="dropdown-item" href="/shawnbot">Your profile</a></li>
-    <li><a class="dropdown-item" href="/shawnbot?tab=stars">Your stars</a></li>
-    <li><a class="dropdown-item" href="https://gist.github.com/">Your Gists</a></li>
-    <li class="dropdown-divider"></li>
-    <li><a class="dropdown-item" href="https://help.github.com">Help</a></li>
-    <li><a class="dropdown-item" href="/settings/profile">Settings</a></li>
-    <li>
-      <form accept-charset="UTF-8" action="/logout" class="logout-form" method="post">
-        <button type="submit" class="dropdown-item dropdown-signout" data-ga-click="Header, sign out, icon:logout">
+      </li>
+      <li class="dropdown-divider"></li>
+      <li><a class="dropdown-item" href="#url">Your profile</a></li>
+      <li><a class="dropdown-item" href="#url">Your stars</a></li>
+      <li><a class="dropdown-item" href="#url">Your Gists</a></li>
+      <li class="dropdown-divider"></li>
+      <li><a class="dropdown-item" href="#url">Help</a></li>
+      <li><a class="dropdown-item" href="#url">Settings</a></li>
+      <li>
+        <form class="m-0" accept-charset="UTF-8" action="#url" class="logout-form" method="post">
+          <button type="submit" class="dropdown-item dropdown-signout">
           Sign out
-        </button>
-      </form>
-    </li>
-  </ul>
+          </button>
+        </form>
+      </li>
+    </ul>
+  </div>
 </div>
 ```
 

--- a/modules/primer-dropdown/README.md
+++ b/modules/primer-dropdown/README.md
@@ -250,6 +250,7 @@ to `auto` and prevent hidden overflows on item contents and text.
     1 member selected…
     <span class="dropdown-caret"></span>
   </button>
+
   <div class="dropdown-menu-content js-menu-content">
     <ul class="dropdown-menu dropdown-menu-no-overflow dropdown-menu-se">
       <a href="#url" class="dropdown-item js-menu-close">
@@ -273,6 +274,7 @@ and display it as a link.
   <button class="btn dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
     <img alt="@shawnbot" class="avatar" src="https://avatars0.githubusercontent.com/u/113896?v=4&amp;s=40" height="20" width="20">
   </button>
+
   <div class="dropdown-menu-content js-menu-content">
     <ul class="dropdown-menu dropdown-menu-sw">
       <li class="dropdown-header header-nav-current-user css-truncate">

--- a/modules/primer-dropdown/README.md
+++ b/modules/primer-dropdown/README.md
@@ -9,7 +9,7 @@ This repository is a module of the full [primer-css][primer-css] repository.
 
 ## Install
 
-This repository is distributed with [npm][npm]. After [installing npm][install-npm], you can install `primer-dropdown` with this command.
+This repository is distributed with [npm]. After [installing npm][install-npm], you can install `primer-dropdown` with this command.
 
 ```
 $ npm install --save primer-dropdown

--- a/modules/primer-dropdown/README.md
+++ b/modules/primer-dropdown/README.md
@@ -3,8 +3,6 @@
 [![npm version](http://img.shields.io/npm/v/primer-dropdown.svg)](https://www.npmjs.org/package/primer-dropdown)
 [![Build Status](https://travis-ci.org/primer/primer-css.svg?branch=master)](https://travis-ci.org/primer/primer-css)
 
-> Dropdowns are lightweight, JavaScript-powered context menus for housing navigation and actions. They're great for instances where you don't need the full power (and code) of the select menu.
-
 This repository is a module of the full [primer-css][primer-css] repository.
 
 ## Install
@@ -39,6 +37,8 @@ $ npm run build
 title: Dropdown
 status: Stable
 -->
+
+Dropdowns are lightweight, JavaScript-powered context menus for housing navigation and actions. They're great for instances where you don't need the full power (and code) of the select menu.
 
 {:toc}
 

--- a/modules/primer-dropdown/README.md
+++ b/modules/primer-dropdown/README.md
@@ -38,7 +38,6 @@ $ npm run build
 <!-- %docs
 title: Dropdown
 status: Stable
-source: https://github.com/github/github/blob/master/app/assets/stylesheets/components/dropdown.scss
 -->
 
 {:toc}

--- a/modules/primer-dropdown/README.md
+++ b/modules/primer-dropdown/README.md
@@ -240,6 +240,56 @@ Align the direction of dropdown menus and their arrows with modifier classes.
 </div>
 ```
 
+### No overflow
+
+```html
+<div class="select-all-dropdown dropdown js-menu-container js-bulk-actions float-left js-transitionable active">
+  <button class="btn btn-sm mr-3 js-menu-target selected" type="button" aria-expanded="true" aria-haspopup="true">
+    1 member selected…
+    <span class="dropdown-caret"></span>
+  </button>
+  <div class="dropdown-menu-content js-menu-content">
+    <ul class="dropdown-menu dropdown-menu-no-overflow dropdown-menu-se">
+      <a href="#change-role-54012" rel="facebox[.change-role-54012]" class="dropdown-item js-menu-close">
+        Change role...
+      </a>
+      <a href="#remove-team-members-54012" class="dropdown-item menu-item-danger js-menu-close">
+        Remove from team
+      </a>
+    </ul>
+  </div>
+</div>
+```
+
+### Sign out button
+
+```html
+<div class="dropdown js-menu-container">
+  <button class="btn dropdown-toggle js-menu-target" type="button" aria-expanded="false" aria-haspopup="true">
+    <img alt="@shawnbot" class="avatar" src="https://avatars0.githubusercontent.com/u/113896?v=4&amp;s=40" height="20" width="20">
+  </button>
+  <ul class="dropdown-menu dropdown-menu-sw">
+    <li class="dropdown-header header-nav-current-user css-truncate">
+      Signed in as <strong class="css-truncate-target">shawnbot</strong>
+    </li>
+    <li class="dropdown-divider"></li>
+    <li><a class="dropdown-item" href="/shawnbot">Your profile</a></li>
+    <li><a class="dropdown-item" href="/shawnbot?tab=stars">Your stars</a></li>
+    <li><a class="dropdown-item" href="https://gist.github.com/">Your Gists</a></li>
+    <li class="dropdown-divider"></li>
+    <li><a class="dropdown-item" href="https://help.github.com">Help</a></li>
+    <li><a class="dropdown-item" href="/settings/profile">Settings</a></li>
+    <li>
+      <form accept-charset="UTF-8" action="/logout" class="logout-form" method="post">
+        <button type="submit" class="dropdown-item dropdown-signout" data-ga-click="Header, sign out, icon:logout">
+          Sign out
+        </button>
+      </form>
+    </li>
+  </ul>
+</div>
+```
+
 <!-- %enddocs -->
 
 ## License

--- a/modules/primer-dropdown/README.md
+++ b/modules/primer-dropdown/README.md
@@ -1,9 +1,9 @@
-# Primer CSS table object
+# Primer CSS dropdown
 
 [![npm version](http://img.shields.io/npm/v/primer-dropdown.svg)](https://www.npmjs.org/package/primer-dropdown)
 [![Build Status](https://travis-ci.org/primer/primer-css.svg?branch=master)](https://travis-ci.org/primer/primer-css)
 
-> Table object is a module for creating dynamically resizable elements that always sit on the same horizontal line (e.g., they never break to a new line). Using table styles in our CSS means it’s cross browser friendly back to at least IE9.
+> Dropdowns are lightweight, JavaScript-powered context menus for housing navigation and actions. They're great for instances where you don't need the full power (and code) of the select menu.
 
 This repository is a module of the full [primer-css][primer-css] repository.
 
@@ -40,8 +40,6 @@ title: Dropdown
 status: Stable
 source: https://github.com/github/github/blob/master/app/assets/stylesheets/components/dropdown.scss
 -->
-
-Dropdowns are lightweight, JavaScript-powered context menus for housing navigation and actions. They're great for instances where you don't need the full power (and code) of the select menu.
 
 {:toc}
 

--- a/modules/primer-dropdown/index.scss
+++ b/modules/primer-dropdown/index.scss
@@ -1,0 +1,1 @@
+@import "./lib/dropdown.scss";

--- a/modules/primer-dropdown/index.scss
+++ b/modules/primer-dropdown/index.scss
@@ -1,1 +1,2 @@
+@import "primer-support/index.scss";
 @import "./lib/dropdown.scss";

--- a/modules/primer-dropdown/lib/dropdown.scss
+++ b/modules/primer-dropdown/lib/dropdown.scss
@@ -1,7 +1,5 @@
 // TODO add some docs here
 
-@import "primer-support/index.scss";
-
 .dropdown {
   position: relative;
 

--- a/modules/primer-dropdown/lib/dropdown.scss
+++ b/modules/primer-dropdown/lib/dropdown.scss
@@ -1,0 +1,262 @@
+// TODO add some docs here
+
+.dropdown {
+  position: relative;
+
+  &.active {
+    .dropdown-menu-content {
+      display: block;
+      pointer-events: all;
+    }
+  }
+}
+
+.dropdown-caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  vertical-align: middle;
+  content: "";
+  border: 4px solid;
+  border-right-color: transparent;
+  border-bottom-color: transparent;
+  border-left-color: transparent;
+}
+
+// Requires a positioning class (e.g., `.dropdown-menu-w`) to determine which
+// way the menu should render from the element triggering it.
+.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 100;
+  width: 160px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  margin-top: 2px;
+  list-style: none;
+  background-color: $bg-white;
+  background-clip: padding-box;
+  border: 1px solid $black-fade-15;
+  border-radius: 4px;
+  box-shadow: 0 3px 12px $black-fade-15;
+
+  &::before,
+  &::after {
+    position: absolute;
+    display: inline-block;
+    content: "";
+  }
+
+  &::before {
+    border: 8px solid transparent;
+    border-bottom-color: $black-fade-15;
+  }
+
+  &::after {
+    border: 7px solid transparent;
+    border-bottom-color: $white;
+  }
+
+  // stylelint-disable-next-line selector-max-type
+  > ul {
+    list-style: none;
+  }
+}
+
+.dropdown-menu-no-overflow {
+  width: auto;
+
+  .dropdown-item {
+    padding: 4px 15px;
+    overflow: visible;
+    text-overflow: inherit;
+  }
+}
+
+// Dropdown items (can be links or buttons)
+.dropdown-item {
+  display: block;
+  padding: 4px 10px 4px 15px;
+  overflow: hidden;
+  color: $text-gray-dark;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &:hover,
+  &.zeroclipboard-is-hover {
+    color: $text-white;
+    text-decoration: none;
+    background-color: $bg-blue;
+
+    > .octicon {
+      color: inherit;
+      opacity: 1;
+    }
+  }
+
+  &.btn-link {
+    width: 100%;
+    text-align: left;
+  }
+}
+
+.dropdown-signout {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: 0;
+}
+
+.dropdown-divider {
+  height: 1px;
+  margin: 8px 1px;
+  background-color: $gray-200;
+}
+
+.dropdown-header {
+  padding: 4px 15px;
+  font-size: 12px;
+  color: $text-gray;
+}
+
+.dropdown-menu-content {
+  display: none;
+
+  // stylelint-disable primer/selector-no-utility
+  &.anim-scale-in {
+    position: relative;
+    z-index: 100;
+    pointer-events: none;
+  }
+}
+
+// Directional classes
+//
+// Move the menu and the caret attached to it. Requires at least one of these on
+// the `.dropdown-menu` element.
+
+.dropdown-menu-w {
+  top: 0;
+  right: 100%;
+  left: auto;
+  width: auto;
+  margin-top: 0;
+  margin-right: 10px;
+
+  &::before {
+    top: 10px;
+    right: -16px;
+    left: auto;
+    border-color: transparent;
+    border-left-color: $black-fade-15;
+  }
+
+  &::after {
+    top: 11px;
+    right: -14px;
+    left: auto;
+    border-color: transparent;
+    border-left-color: $white;
+  }
+}
+
+.dropdown-menu-e {
+  top: 0;
+  left: 100%;
+  width: auto;
+  margin-top: 0;
+  margin-left: 10px;
+
+  &::before {
+    top: 10px;
+    left: -16px;
+    border-color: transparent;
+    border-right-color: $black-fade-15;
+  }
+
+  &::after {
+    top: 11px;
+    left: -14px;
+    border-color: transparent;
+    border-right-color: $white;
+  }
+}
+
+.dropdown-menu-ne {
+  top: auto;
+  bottom: 100%;
+  left: 0;
+  margin-bottom: 3px;
+
+  &::before,
+  &::after {
+    top: auto;
+    right: auto;
+  }
+
+  &::before {
+    bottom: -8px;
+    left: 9px;
+    border-top: 8px solid $black-fade-15;
+    border-right: 8px solid transparent;
+    border-bottom: 0;
+    border-left: 8px solid transparent;
+  }
+
+  &::after {
+    bottom: -7px;
+    left: 10px;
+    border-top: 7px solid $white;
+    border-right: 7px solid transparent;
+    border-bottom: 0;
+    border-left: 7px solid transparent;
+  }
+}
+
+.dropdown-menu-s {
+  right: 50%;
+  left: auto;
+  transform: translateX(50%);
+
+  &::before {
+    top: -16px;
+    right: 50%;
+    transform: translateX(50%);
+  }
+
+  &::after {
+    top: -14px;
+    right: 50%;
+    transform: translateX(50%);
+  }
+}
+
+.dropdown-menu-sw {
+  right: 0;
+  left: auto;
+
+  &::before {
+    top: -16px;
+    right: 9px;
+    left: auto;
+  }
+
+  &::after {
+    top: -14px;
+    right: 10px;
+    left: auto;
+  }
+}
+
+.dropdown-menu-se {
+  &::before {
+    top: -16px;
+    left: 9px;
+  }
+
+  &::after {
+    top: -14px;
+    left: 10px;
+  }
+}

--- a/modules/primer-dropdown/lib/dropdown.scss
+++ b/modules/primer-dropdown/lib/dropdown.scss
@@ -1,5 +1,7 @@
 // TODO add some docs here
 
+@import "primer-support/index.scss";
+
 .dropdown {
   position: relative;
 

--- a/modules/primer-dropdown/package.json
+++ b/modules/primer-dropdown/package.json
@@ -8,7 +8,7 @@
   "style": "index.scss",
   "main": "build/index.js",
   "primer": {
-    "category": "core",
+    "category": "product",
     "module_type": "components"
   },
   "files": [

--- a/modules/primer-dropdown/package.json
+++ b/modules/primer-dropdown/package.json
@@ -1,0 +1,39 @@
+{
+  "version": "0.1.0",
+  "name": "primer-dropdown",
+  "description": "A lightweight context menu for navigation and actions.",
+  "homepage": "http://primercss.io/",
+  "author": "GitHub, Inc.",
+  "license": "MIT",
+  "style": "index.scss",
+  "main": "build/index.js",
+  "primer": {
+    "category": "core",
+    "module_type": "components"
+  },
+  "files": [
+    "index.scss",
+    "lib",
+    "build"
+  ],
+  "repository": "https://github.com/primer/primer-css/tree/master/modules/primer-dropdown",
+  "bugs": {
+    "url": "https://github.com/primer/primer-css/issues"
+  },
+  "scripts": {
+    "test-docs": "ava --verbose ../../tests/modules/test-*.js",
+    "build": "primer-module-build index.scss",
+    "prepare": "npm run build",
+    "lint": "stylelint **/*.scss -s scss",
+    "test": "npm-run-all -s build lint test-docs"
+  },
+  "dependencies": {
+    "primer-support": "4.3.0"
+  },
+  "keywords": [
+    "primer",
+    "css",
+    "github",
+    "primercss"
+  ]
+}

--- a/modules/primer-dropdown/package.json
+++ b/modules/primer-dropdown/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "1.0.0",
   "name": "primer-dropdown",
   "description": "A lightweight context menu for navigation and actions.",
   "homepage": "http://primercss.io/",

--- a/modules/primer-dropdown/package.json
+++ b/modules/primer-dropdown/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.1.0",
   "name": "primer-dropdown",
   "description": "A lightweight context menu for navigation and actions.",
   "homepage": "http://primercss.io/",

--- a/modules/primer-forms/LICENSE
+++ b/modules/primer-forms/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-labels/LICENSE
+++ b/modules/primer-labels/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-layout/LICENSE
+++ b/modules/primer-layout/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-markdown/LICENSE
+++ b/modules/primer-markdown/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-marketing-support/LICENSE
+++ b/modules/primer-marketing-support/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-marketing-type/LICENSE
+++ b/modules/primer-marketing-type/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-marketing-utilities/LICENSE
+++ b/modules/primer-marketing-utilities/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-marketing/LICENSE
+++ b/modules/primer-marketing/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-navigation/LICENSE
+++ b/modules/primer-navigation/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-page-headers/LICENSE
+++ b/modules/primer-page-headers/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-page-sections/LICENSE
+++ b/modules/primer-page-sections/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-product/LICENSE
+++ b/modules/primer-product/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-product/index.scss
+++ b/modules/primer-product/index.scss
@@ -17,5 +17,6 @@
 @import "primer-alerts/index.scss";
 @import "primer-avatars/index.scss";
 @import "primer-blankslate/index.scss";
+@import "primer-dropdown/index.scss";
 @import "primer-labels/index.scss";
 @import "primer-markdown/index.scss";

--- a/modules/primer-product/package.json
+++ b/modules/primer-product/package.json
@@ -28,7 +28,7 @@
     "primer-alerts": "1.4.0",
     "primer-avatars": "1.3.0",
     "primer-blankslate": "1.3.0",
-    "primer-dropdown": "1.0.0",
+    "primer-dropdown": "0.1.0",
     "primer-labels": "1.4.0",
     "primer-markdown": "3.6.0",
     "primer-support": "4.3.0"

--- a/modules/primer-product/package.json
+++ b/modules/primer-product/package.json
@@ -28,6 +28,7 @@
     "primer-alerts": "1.4.0",
     "primer-avatars": "1.3.0",
     "primer-blankslate": "1.3.0",
+    "primer-dropdown": "1.0.0",
     "primer-labels": "1.4.0",
     "primer-markdown": "3.6.0",
     "primer-support": "4.3.0"

--- a/modules/primer-support/LICENSE
+++ b/modules/primer-support/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-table-object/LICENSE
+++ b/modules/primer-table-object/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-tables/LICENSE
+++ b/modules/primer-tables/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-tooltips/LICENSE
+++ b/modules/primer-tooltips/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-truncate/LICENSE
+++ b/modules/primer-truncate/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/primer-utilities/LICENSE
+++ b/modules/primer-utilities/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub Inc.
+Copyright (c) 2017 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This adds the `primer-dropdown` component module (based off `primer-table-object` because it seemed to be one of the simpler ones), and adds it to the `primer-product` meta-package.

I had to add some examples of the `dropdown-no-overflow` and `dropdown-signout` classes to get the docs test to pass, but otherwise this was a pretty easy task. Here's what I did to kick things off:

```sh
cp -r primer-table-object primer-dropdown
cd primer-dropdown
perl -pi -e 's/table-object/dropdown/g' index.scss package.json README.md
rm lib/table-object.scss
cp ~/github/github/.../dropdown.scss lib
```

I used code search to find the view templates that use the `dropdown-no-overflow` and `dropdown-signout` classes, hunted down instances of those on github.com, copied them over, cleaned up the markup (reformatted, removed facebox and GA stuff), then ran:

```sh
npm test -- --scope=primer-dropdown
```

### TODO
- [x] Review
- [x] Test on the style guide
