### PR TITLE
Deprecate marketing cards module and credit cards component

### DIFF
--- a/modules/primer-cards/README.md
+++ b/modules/primer-cards/README.md
@@ -1,7 +1,11 @@
-# Primer Marketing CSS Cards
 
+# Primer Marketing CSS Cards
 [![npm version](http://img.shields.io/npm/v/primer-cards.svg)](https://www.npmjs.org/package/primer-cards)
 [![Build Status](https://travis-ci.org/primer/primer-css.svg?branch=master)](https://travis-ci.org/primer/primer-css)
+
+# ⚠️ primer-cards is being deprecated in primer-css@10. Use primer-box instead.
+
+
 
 > Card-like containers to group semantically related content together on marketing websites at GitHub.
 

--- a/modules/primer-cards/README.md
+++ b/modules/primer-cards/README.md
@@ -3,7 +3,7 @@
 [![npm version](http://img.shields.io/npm/v/primer-cards.svg)](https://www.npmjs.org/package/primer-cards)
 [![Build Status](https://travis-ci.org/primer/primer-css.svg?branch=master)](https://travis-ci.org/primer/primer-css)
 
-# ⚠️ primer-cards is being deprecated in primer-css@10. Use primer-box instead.
+# ⚠️ The primer-cards module is being deprecated in the next major version. Use primer-box instead.
 
 
 

--- a/modules/primer-cards/index.scss
+++ b/modules/primer-cards/index.scss
@@ -1,4 +1,6 @@
 // support files
+@warn "primer-cards is being deprecated in primer-css@10. Use primer-box instead.";
+
 @import "primer-support/index.scss";
 @import "primer-marketing-support/index.scss";
 @import "./lib/cards.scss";

--- a/modules/primer-cards/index.scss
+++ b/modules/primer-cards/index.scss
@@ -1,5 +1,5 @@
 // support files
-@warn "primer-cards: The primer-cards modules is being deprecated in the next major version. Use primer-box instead.";
+@warn "primer-cards: The primer-cards module is being deprecated in the next major version. Use primer-box instead.";
 
 @import "primer-support/index.scss";
 @import "primer-marketing-support/index.scss";

--- a/modules/primer-cards/index.scss
+++ b/modules/primer-cards/index.scss
@@ -1,5 +1,5 @@
 // support files
-@warn "primer-cards is being deprecated in primer-css@10. Use primer-box instead.";
+@warn "primer-cards: The primer-cards modules is being deprecated in the next major version. Use primer-box instead.";
 
 @import "primer-support/index.scss";
 @import "primer-marketing-support/index.scss";

--- a/modules/primer-forms/lib/form-validation.scss
+++ b/modules/primer-forms/lib/form-validation.scss
@@ -52,7 +52,7 @@ dl.form-group > dd {
 // A selector for credit cards. Shows all credit cards we have available and
 // dims the non-selected ones.
 
-@warn "primer-forms: The credit cards component is being deprecated in next major version."
+@warn "primer-forms: The credit cards component is being deprecated in next major version.";
 
 .form-cards {
   height: 31px;

--- a/modules/primer-forms/lib/form-validation.scss
+++ b/modules/primer-forms/lib/form-validation.scss
@@ -52,6 +52,8 @@ dl.form-group > dd {
 // A selector for credit cards. Shows all credit cards we have available and
 // dims the non-selected ones.
 
+@warn "primer-forms: The credit cards component is being deprecated in next major version."
+
 .form-cards {
   height: 31px;
   margin: 0 0 15px;


### PR DESCRIPTION
This PR adds some notes to the primer-cards module and the primer-forms module about upcoming deprecation.

For the `primer-cards` module, the whole thing is going away in the next major version. So I'm adding a `@warn`, a banner on the readme, and running `npm deprecate primer-cards@"> 0.4.0" "The primer-cards module is being deprecated in the next major version. Use primer-box instead."`

For the forms credit cards, I'm adding a warning near the css, until we remove it.

/cc @primer/ds-core
