### PR TITLE
Change markdown li break to handle Safari 10.x user stylesheet bug

### DIFF
--- a/modules/primer-markdown/lib/lists.scss
+++ b/modules/primer-markdown/lib/lists.scss
@@ -45,6 +45,10 @@
     margin-bottom: 0;
   }
 
+  li {
+    word-wrap: break-all;
+  }
+
   li > p {
     margin-top: $spacer-3;
   }


### PR DESCRIPTION
Hey friends 👋 !

I am working on some [bugs internally](https://github.com/github/github/issues/76971) that are related to how long bullets in the body of an issue, PR, and project card are wrapping in Safari. I'm testing locally in Safari 10.1.2 and Chrome 61.0.3163.100 (wow that is a long version number). This bug _does not happen_ with Safari 11.

Based on the testing I've been doing, it looks like `word-wrap: break-word;` behaves _differently_ for when `display` is set to `list-item`. Once I change that `display` property to **literally anything else** the bug fixes itself, but we lose the bullet formatting. Changing the `li` elements to wrap as `break-all` resolves the issue in Safari, and there are no visible changes in Chrome. I'm happy to screen share with one of y'all and show you what I've been testing over here if you're having trouble reproducing or have a newer version of Safari 😊 !

I'm super new to our CSS and did some poking around in the documentation to see how to go about changing this for dotcom. I am not sure that changing this in Primer is the best approach, but it seems like overriding the Markdown `li` formatting in our stylesheets for a browser bug is not the right way to go about this either. My thinking regarding changing it in Primer was that because it's a bug with Safari 10.x that is **not** isolated to GitHub's internal styles, it will impact other folks using Primer. _However_ since this is a bug restricted to an older version of Safari, I can see how we wouldn't want that bloat here.

Let me know what you think! 🙇‍♀️ Happy to pair on an alternative solution also 👏 💯 

/cc @primer/ds-core
