### PR TITLE
Add .details-reset

### DIFF
--- a/modules/primer-base/lib/base.scss
+++ b/modules/primer-base/lib/base.scss
@@ -65,3 +65,12 @@ th {
 button {
   cursor: pointer;
 }
+
+details {
+  summary { cursor: pointer; }
+
+  &:not([open]) {
+    // Set details content hidden by default for browsers that don't do this
+    > *:not(summary) { display: none; }
+  }
+}

--- a/modules/primer-buttons/lib/button.scss
+++ b/modules/primer-buttons/lib/button.scss
@@ -202,3 +202,12 @@
     }
   }
 }
+
+.details-reset {
+  // Remove marker added by the display: list-item browser default
+  > summary { list-style: none; }
+  // Remove marker added by details polyfill
+  > summary::before { display: none; }
+  // Remove marker added by Chrome
+  > summary::-webkit-details-marker { display: none; }
+}


### PR DESCRIPTION
A follow up for #346. 

@shawnbot has recommend that we bring `.details-reset` out into Primer soon rather than later. I have 2 PRs in github/github needing this class as well. 

I put `.details-reset` in buttons since it's resetting `<summary>` and `<summary>` is [_like_ a button](https://www.w3.org/TR/html-aam-1.0/#summary-and-details-elements).

> The summary element should be mapped to a disclosure triangle role in accessibility APIs that have such a role. ... In accessibility APIs that do not have such a fine grained role, the summary element should be mapped to a button role.

Feel free to let me know if there is a better place for them. :)

/cc @primer/ds-core
