### PR TITLE
Publish alpha release any time we're not on a release branch or master

### DIFF
--- a/script/after_success
+++ b/script/after_success
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
 
-branch=$TRAVIS_BRANCH
+branch=$TRAVIS_PULL_REQUEST_BRANCH
 event=$TRAVIS_EVENT_TYPE
 
 # only publish canary releases on PRs against dev
-if [[ "$event" = "pull_request" && "$branch" = "dev" ]]; then
+if [[ "$event" = "pull_request" ]] && [[ !("$branch" =~ ^release-.*) ]] && [[ !("$branch" = "master") ]];
+then
   script/release-pr --yes
 fi


### PR DESCRIPTION
This is a small fix to the `alpha` release script to run it any time we're not on a `release-*` branch or a `master` branch. Rather than only if we're pointing the pr at `dev`.

I think this is better because it defaults on the side of publishing alpha releases rather than not doing anything.

The logic is as follows:

- Build on `master` branch with new versions in package.json will publish full release
- Build on PR with branch named `release-` will publish a release candidate.
- Every other PR will build and publish an `alpha` npm release.

I'm going to add this to v10 https://github.com/primer/primer-css/pull/354

cc @broccolini 