### PR TITLE
Using lerna-changelog to generate a changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 build
 _site
 *.lerna_backup
+.changelog

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
     - secure: "EZewKKWQXmtCwPtYrPZq4OQblv2OyXR61qBIl3pOxGNVG2BCjD6VOgSaiYqkA9Qbt+ihfwQkiiLvTB68gbvRSiBFV9i+XLzKzt4S8CDI5RhTLAxZB3eQFVZRYzldchzWI4sdNhTvYS1kYXmsXQZD6vJmPSnFvOI/ddfzqvnNL4M="
     # github
     - secure: "J+1oWjvvXjyrwkY/4IFWKdN/weFmQcPwlRuFG4R0Gb3rYe4nqtC9l68sJvmS8asc8dQMhOhcUZCH6sjvo7l2WD4NuK4umPSbs+rJNUsfbvH4pZjStQIj/3ll1OfQelGDWAYQWhIfciYY4F3Bp0ZWTfKOppLQ2AVIYu1fPVXDdlo="
+    # github changelog
+    - secure: "KcGydAqL7ryDh2rTJJB4wU8NE5BRtnrRXDEcPBScSscO3zFsHXHBDvvO04B/9hFVatXzGYXmkn+FZ0P9QikhvebzdwwyqUG2SKFiHhMvbX0m0WtAhn5NqDuKU1r5qy5YQ18r/tiLfC9GSAlEpfLAH58pwpcn8srV3Mn/yKvlrfs="
 
 script:
   - npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,45 @@
-# 10.0.0
+# 10.0.0 (2017-11-10)
 
-### Added
-- New module `primer-subhead`. The Subhead is a simple header with a bottom border. It&#39;s designed to be used on settings and configuration pages.
-- Importing `.input-group` into `primer-forms` module.
-- New module `primer-branch-name` "A nice, consistent way to display branch names."
+#### :boom: Breaking Change
+* [#379](https://github.com/primer/primer-css/pull/379) Deprecating primer-cards and form-cards. ([@jonrohan](https://github.com/jonrohan))
 
-### Removed
-- Removing `primer-cards` module.
-- Removing `.form-cards` styles.
+#### :rocket: Enhancement
+* [#371](https://github.com/primer/primer-css/pull/371) Add .details-reset. ([@muan](https://github.com/muan))
+* [#375](https://github.com/primer/primer-css/pull/375) New utilities & docs - fade out, hover grow, border white fade, responsive positioning, and circle. ([@sophshep](https://github.com/sophshep))
+* [#383](https://github.com/primer/primer-css/pull/383) Add 'Popover' component. ([@brandonrosage](https://github.com/brandonrosage))
+* [#377](https://github.com/primer/primer-css/pull/377) Refactor underline nav. ([@ampinsk](https://github.com/ampinsk))
+* [#337](https://github.com/primer/primer-css/pull/337) Add marketing buttons to primer-marketing-buttons. ([@gladwearefriends](https://github.com/gladwearefriends))
+* [#342](https://github.com/primer/primer-css/pull/342) Import Subhead component. ([@shawnbot](https://github.com/shawnbot))
+* [#341](https://github.com/primer/primer-css/pull/341) Import branch-name component from github/github. ([@shawnbot](https://github.com/shawnbot))
 
-### Changes
-- Moving `primer-breadcrumb` from `primer-marketing` to `primer-core`
-- added `border-radius: 0` to `button` to account for updates in Chroma 62 macOS
+#### :bug: Bug Fix
+* [#360](https://github.com/primer/primer-css/pull/360) Removing ::before ::after padding hack on markdown. ([@jonrohan](https://github.com/jonrohan))
+* [#320](https://github.com/primer/primer-css/pull/320) remove -webkit-text-decoration-skip override. ([@antons](https://github.com/antons))
+* [#359](https://github.com/primer/primer-css/pull/359) Change markdown li break to handle Safari 10.x user stylesheet bug. ([@feministy](https://github.com/feministy))
+* [#388](https://github.com/primer/primer-css/pull/388) [WIP] Button border-radius fix. ([@broccolini](https://github.com/broccolini))
+* [#307](https://github.com/primer/primer-css/pull/307) Do not suppress opacity transition for tooltipped-no-delay. ([@astorije](https://github.com/astorije))
+
+#### :house: Internal
+* [#382](https://github.com/primer/primer-css/pull/382) Update Button docs. ([@JasonEtco](https://github.com/JasonEtco))
+* [#390](https://github.com/primer/primer-css/pull/390) Updating storiesFromMarkdown to read in rails octicons helper and replace with react component. ([@jonrohan](https://github.com/jonrohan))
+* [#389](https://github.com/primer/primer-css/pull/389) Publish alpha release any time we're not on a release branch or master. ([@jonrohan](https://github.com/jonrohan))
+* [#384](https://github.com/primer/primer-css/pull/384) Adding a test to check for the current year in the license and source…. ([@jonrohan](https://github.com/jonrohan))
+* [#374](https://github.com/primer/primer-css/pull/374) Improve Pull Request template. ([@agisilaos](https://github.com/agisilaos))
+
+#### Committers: 13
+- Agisilaos Tsaraboulidis ([agisilaos](https://github.com/agisilaos))
+- Amanda Pinsker ([ampinsk](https://github.com/ampinsk))
+- Anton Sotkov ([antons](https://github.com/antons))
+- Brandon Rosage ([brandonrosage](https://github.com/brandonrosage))
+- Catherine Bui ([gladwearefriends](https://github.com/gladwearefriends))
+- Diana Mounter ([broccolini](https://github.com/broccolini))
+- Jason Etcovitch ([JasonEtco](https://github.com/JasonEtco))
+- Jon Rohan ([jonrohan](https://github.com/jonrohan))
+- Jérémie Astori ([astorije](https://github.com/astorije))
+- Mu-An ✌️ Chiou ([muan](https://github.com/muan))
+- Shawn Allen ([shawnbot](https://github.com/shawnbot))
+- Sophie Shepherd ([sophshep](https://github.com/sophshep))
+- liz abinante! ([feministy](https://github.com/feministy))
 
 # 9.6.0
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,17 @@
     "modules/*",
     "tools/*"
   ],
+  "changelog": {
+    "repo": "primer/primer-css",
+    "labels": {
+      "Tag: Breaking Change": ":boom: Breaking Change",
+      "Tag: Enhancement": ":rocket: Enhancement",
+      "Tag: Bug Fix": ":bug: Bug Fix",
+      "Tag: Polish": ":nail_care: Polish",
+      "Tag: Documentation": ":memo: Documentation",
+      "Tag: Internal": ":house: Internal"
+    },
+    "cacheDir": ".changelog"
+  },
   "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "html-to-react": "^1.2.11",
     "isomorphic-fetch": "^2.2.1",
     "lerna": "^2.4.0",
+    "lerna-changelog": "^0.7.0",
     "node-sass": "^4.5.3",
     "npm-run-all": "^4.0.2",
     "octicons": "^6.0.1",

--- a/script/release
+++ b/script/release
@@ -8,6 +8,8 @@ $(dirname $0)/notify pending
 # published version
 $(npm bin)/lerna exec -- $(pwd)/script/try-publish
 
+echo "📓  Updated CHANGELOG..."
+
 $(npm bin)/lerna-changelog
 
 $(dirname $0)/notify success

--- a/script/release
+++ b/script/release
@@ -8,4 +8,6 @@ $(dirname $0)/notify pending
 # published version
 $(npm bin)/lerna exec -- $(pwd)/script/try-publish
 
+$(npm bin)/lerna-changelog
+
 $(dirname $0)/notify success

--- a/script/release-pr
+++ b/script/release-pr
@@ -8,6 +8,8 @@ echo "🐦  Publishing PR (canary) release..."
 
 $(npm bin)/lerna publish --npm-tag=pr --canary --exact $@
 
+echo "📓  Updated CHANGELOG..."
+
 $(npm bin)/lerna-changelog
 
 $(dirname $0)/notify success

--- a/script/release-pr
+++ b/script/release-pr
@@ -8,4 +8,6 @@ echo "🐦  Publishing PR (canary) release..."
 
 $(npm bin)/lerna publish --npm-tag=pr --canary --exact $@
 
+$(npm bin)/lerna-changelog
+
 $(dirname $0)/notify success


### PR DESCRIPTION
This uses https://github.com/lerna/lerna-changelog to generate the same changelog output you see in https://github.com/lerna/lerna/releases/tag/v2.5.0

To run it locally you'll need to follow the commands in the readme https://github.com/lerna/lerna-changelog#usage

But I've configured travis to output the changelog on every canary and release candidate build. We can copy the output and paste into the changelog.